### PR TITLE
Add:認証後のユーザーページを簡易的に実装

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -10,13 +10,13 @@ class OauthsController < ApplicationController
       return
     end
     if @user = login_from(provider)
-      redirect_to root_path, notice: "#{provider.titleize}ログインしました。"
+      redirect_to user_path(@user), notice: "#{provider.titleize}ログインしました。"
     else
       begin
         @user = create_from(provider)
         reset_session
         auto_login(@user)
-        redirect_to root_path, notice: "#{provider.titleize}ログインしました。"
+        redirect_to user_path(@user), notice: "#{provider.titleize}ログインしました。"
       rescue
         redirect_to root_path, alert: "#{provider.titleize}ログインに失敗しました。"
       end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,0 +1,6 @@
+class UserSessionsController < ApplicationController
+  def destroy
+    logout
+    redirect_to root_path, notice: 'ログアウトしました'
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,15 @@
+class UsersController < ApplicationController
+  def show
+    @user = User.find_by(id: params[:id])
+  end
+
+  def edit; end
+
+  def update; end
+
+  def destroy
+    @user = User.find(params[:id])
+    @user.destroy!
+    redirect_to root_path, notice: 'ユーザーを削除しました'
+  end
+end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,6 @@
+<h1>Users#show</h1>
+<p>Find me in app/views/users/show.html.erb</p>
+<%= @user.name %>
+<%= @user.twitter_id %>
+<%= image_tag @user.image %>
+<%= @user.introduce %>

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -119,9 +119,9 @@ Rails.application.config.sorcery.configure do |config|
   config.twitter.secret = Rails.application.credentials.twitter[:secret]
   config.twitter.callback_url = 'http://127.0.0.1:3000/oauth/callback?provider=twitter'
   config.twitter.user_info_mapping = {
-    twitter_id: 'id',
-    name: 'screen_name',
-    image: 'profile_image_url',
+    twitter_id: 'screen_name',
+    name: 'name',
+    image: 'profile_image_url_https',
     introduce: 'description',
   }
   #


### PR DESCRIPTION
## 概要

Twitter認証後のユーザーページを簡易的に実装。

## 確認方法
ログイン認証した後にusersのshowへ遷移すること。
Twitterアカウント情報がviewに反映されていること。
twitterから受け取るデータ名を間違えて指定していたためconfigファイルを修正。

## コメント
裏側の処理が動作していることを確認出来るようにしている。（レイアウトは未実装）