### PR TITLE
一覧表示機能の実装（受け取ったリスト・送ったリスト）

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -3,13 +3,27 @@ class Api::UsersController < ApplicationController
   def sent_letters
     user = User.find(params[:id])
     @sent_letters = user.letters
-    render json: @sent_letters
+    sent_letters = @sent_letters.map do |letter|
+      {
+        letter: letter,
+        sender: letter.sender,
+        receiver: letter.receiver
+      }
+    end
+    render json: sent_letters
   end
 
   def received_letters
     user = User.find(params[:id])
     @received_letters = user.receivers
-    render json: @received_letters
+    received_letters = @received_letters.map do |letter|
+      {
+        letter: letter,
+        sender: letter.sender,
+        receiver: letter.receiver
+      }
+    end
+    render json: received_letters
   end
 
   def show

--- a/app/javascript/pages/components/LetterItem.vue
+++ b/app/javascript/pages/components/LetterItem.vue
@@ -7,7 +7,13 @@
       <v-list-item>
         <v-list-item-content>
           <v-list-item-title>{{ letter.title }}</v-list-item-title>
-          <v-list-item-subtitle>{{ letter.text }}</v-list-item-subtitle>
+            <v-card
+              class="mt-2 pa-4 rounded-lg u-pre-wrap"
+              outlined
+              rounded="xl"
+              max-width="650"
+            > {{ letter.text }}
+            </v-card>
         </v-list-item-content>
       </v-list-item>
     </v-list-item>
@@ -25,6 +31,10 @@ export default {
       type: Object,
       required: true
     },
+    sentLetters: {
+      type: Object,
+      required: true
+    }
   },
   computed: {
     createdLetter() {
@@ -32,22 +42,22 @@ export default {
         {
           name: "past",
           title: "出会いのきっかけ、当時の印象",
-          text: this.letterItems.past
+          text: this.letterItems.letter.past
         },
         {
           name: "current",
           title: "現在の印象、どんな人？",
-          text: this.letterItems.current
+          text: this.letterItems.letter.current
         },
         {
           name: "future",
           title: "これから話してみたい／聞いてみたいこと",
-          text: this.letterItems.future
+          text: this.letterItems.letter.future
         },
         {
           name: "expect",
           title: `${ this.user.name }さんに期待していること`,
-          text: this.letterItems.expect
+          text: this.letterItems.letter.expect
         },
         {
           name: "message",
@@ -64,4 +74,7 @@ export default {
 
 
 <style scoped>
+.u-pre-wrap {
+  white-space: pre-wrap;
+}
 </style>

--- a/app/javascript/pages/components/LetterListReceived.vue
+++ b/app/javascript/pages/components/LetterListReceived.vue
@@ -1,55 +1,70 @@
 <template>
-  <v-container>
-    <v-row
-      class="ma-8"
-      justify="center"
+  <v-container class="pa-0">
+    <div
+      v-for="letterItem in letterItems"
+      :key="letterItem.id"
     >
       <v-card
+        color="grey lighten-4"
         flat
-        color="amber lighten-5"
-        width="800px"
-        rounded="xl"
       >
-        <v-card-title class="ps-16">
-          <router-link :to="{ name: 'UserIndex', params: { id: user.id }}">
-            <v-list-item-avatar size="50">
-              <img :src="user.image">
-            </v-list-item-avatar>
-          </router-link>
-          <v-list-item-content>
-            <v-list-item-title class="font-bold">
-              {{ user.name }}
-            </v-list-item-title>
-            <v-list-item-subtitle>
-              @{{ user.twitter_id }}
-              <v-btn
-                icon
-                color="blue"
-                :href="twitterUrl"
-              >
-                <v-icon>mdi-twitter</v-icon>
-              </v-btn>
-            </v-list-item-subtitle>
-          </v-list-item-content>
-        </v-card-title>
-
-        <LetterItem
-          :letter-items="letterItems"
-          :user="user"
-        />
-        <v-col class="text-center">
-          <v-btn
-            color="blue"
-            class="white--text"
-            small
-            @click="openShareLetterModal"
+        <keep-alive>
+          <v-row
+            class="ma-8"
+            justify="center"
           >
-            <v-icon>mdi-twitter</v-icon>
-            シェア
-          </v-btn>
-        </v-col>
+            <v-card
+              flat
+              color="blue-grey lighten-5"
+              width="800px"
+              rounded="xl"
+            >
+              <v-card-title class="ps-16">
+                <router-link :to="{ name: 'UserIndex', params: { id: letterItem.sender.id }}">
+                  <v-list-item-avatar size="50">
+                    <img :src="letterItem.sender.image">
+                  </v-list-item-avatar>
+                </router-link>
+                <v-list-item-content>
+                  <v-list-item-title class="font-bold">
+                    {{ letterItem.sender.name }}
+                  </v-list-item-title>
+                  <v-list-item-subtitle>
+                    @{{ letterItem.sender.twitter_id }}
+                    <v-btn
+                      icon
+                      color="blue"
+                      :href="twitterUrl"
+                    >
+                      <v-icon>mdi-twitter</v-icon>
+                    </v-btn>
+                  </v-list-item-subtitle>
+                </v-list-item-content>
+              </v-card-title>
+              <LetterItem
+                :letter-items="letterItem"
+                :sent-letters="letterItem"
+                :user="user"
+              />
+              <v-row
+                justify="end"
+                class="ma-4"
+              >
+                <v-btn
+                  color="blue"
+                  class="white--text"
+                  small
+                  @click="openShareLetterModal"
+                >
+                  <v-icon>mdi-twitter</v-icon>
+                  シェア
+                </v-btn>
+              </v-row>
+            </v-card>
+          </v-row>
+        </keep-alive>
       </v-card>
-    </v-row>
+    </div>
     <transition name="fade">
       <ShareLetterModal
         :is-visible-share-letter-modal="isVisibleShareLetterModal"
@@ -60,6 +75,7 @@
 </template>
 
 <script>
+import axios from "axios";
 import { mapGetters } from "vuex"
 import LetterItem from '../components/LetterItem';
 import ShareLetterModal from "./ShareLetterModal";
@@ -75,7 +91,7 @@ export default {
       required: true
     },
     letterItems: {
-      type: Object,
+      type: Array,
       required: true
     },
   },
@@ -88,7 +104,7 @@ export default {
     ...mapGetters({ currentUser: "users/currentUser" }),
     twitterUrl() {
       return `https://twitter.com/${this.currentUser.twitter_id}`
-    }
+    },
   },
   methods: {
     openShareLetterModal() {

--- a/app/javascript/pages/components/LetterListSent.vue
+++ b/app/javascript/pages/components/LetterListSent.vue
@@ -1,44 +1,61 @@
 <template>
-  <v-container>
-    <v-row
-      class="ma-8"
-      justify="center"
+  <v-container class="pa-0">
+    <div
+      v-for="letter in sentLetters"
+      :key="letter.id"
     >
       <v-card
+        color="grey lighten-4"
         flat
-        color="amber lighten-5"
-        width="800px"
-        rounded="xl"
       >
-        <v-card-title class="ps-16">
-          <router-link :to="{ name: 'UserIndex', params: { id: currentUser.id }}">
-            <v-list-item-avatar size="50">
-              <img :src="currentUser.image">
-            </v-list-item-avatar>
-          </router-link>
-          <v-list-item-content>
-            <v-list-item-title class="font-bold">
-              {{ currentUser.name }}
-            </v-list-item-title>
-            <v-list-item-subtitle>
-              @{{ currentUser.twitter_id }}
-              <v-btn
-                icon
-                color="blue"
-                :href="twitterUrl"
+        <keep-alive>
+          <v-row
+            class="ma-8"
+            justify="center"
+          >
+            <v-card
+              flat
+              color="blue-grey lighten-5"
+              width="800px"
+              rounded="xl"
+            >
+              <v-card-title class="ps-16">
+                <router-link :to="{ name: 'UserIndex', params: { id: letter.receiver.id }}">
+                  <v-list-item-avatar size="50">
+                    <img :src="letter.receiver.image">
+                  </v-list-item-avatar>
+                </router-link>
+                <v-list-item-content>
+                  <v-list-item-title class="font-bold">
+                    {{ letter.receiver.name }}
+                  </v-list-item-title>
+                  <v-list-item-subtitle>
+                    @{{ letter.receiver.twitter_id }}
+                    <v-btn
+                      icon
+                      color="blue"
+                      :href="twitterUrl"
+                    >
+                      <v-icon>mdi-twitter</v-icon>
+                    </v-btn>
+                  </v-list-item-subtitle>
+                </v-list-item-content>
+              </v-card-title>
+              <LetterItem
+                :letter-items="letter"
+                :sent-letters="letter"
+                :user="user"
+              />
+              <v-row
+                justify="end"
+                class="ma-4"
               >
-                <v-icon>mdi-twitter</v-icon>
-              </v-btn>
-            </v-list-item-subtitle>
-          </v-list-item-content>
-        </v-card-title>
-
-        <LetterItem
-          :letter-items="letterItems"
-          :user="user"
-        />
+              </v-row>
+            </v-card>
+          </v-row>
+        </keep-alive>
       </v-card>
-    </v-row>
+    </div>
   </v-container>
 </template>
 
@@ -55,16 +72,17 @@ export default {
       type: Object,
       required: true
     },
-    letterItems: {
-      type: Object,
+
+    sentLetters: {
+      type: Array,
       required: true
-    },
+    }
 },
   computed: {
     ...mapGetters({ currentUser: "users/currentUser" }),
     twitterUrl() {
       return `https://twitter.com/${this.currentUser.twitter_id}`
-    }
+    },
   },
   methods: {
 

--- a/app/javascript/pages/components/LetterListTab.vue
+++ b/app/javascript/pages/components/LetterListTab.vue
@@ -12,7 +12,7 @@
         <v-tab
           v-for="tabItem in tabItems"
           :key="tabItem.tabId"
-          class="mr-20"
+          class="mr-24"
         >
           {{ tabItem.tabName }}
           <v-icon>mdi-email-edit-outline</v-icon>
@@ -23,23 +23,12 @@
           v-for="tabItem in tabItems"
           :key="tabItem.tabId"
         >
-          <div
-            v-for="letter in letterItems"
-            :key="letter.id"
-          >
-            <v-card
-              flat
-              class="mt-3"
-            >
-              <keep-alive>
-                <component
-                  :is="tabItem.content"
-                  :user="user"
-                  :letter-items="letter"
-                />
-              </keep-alive>
-            </v-card>
-          </div>
+          <component
+            :is="tabItem.content"
+            :user="user"
+            :letter-items="letterItems"
+            :sent-letters="sentLetters"
+          />
         </v-tab-item>
       </v-tabs-items>
     </v-row>
@@ -64,6 +53,10 @@ export default {
       type: Array,
       required: true
     },
+    sentLetters: {
+      type: Array,
+      required: true
+    }
   },
   data() {
     return {
@@ -74,14 +67,6 @@ export default {
       ]
     }
   },
-  methods: {
-    async fetchSentLetters() {
-      await axios.get(`/api/users/${this.$route.params.id}/sent_letters`)
-        .then((res) => {
-          this.sentLetters = res.data
-        })
-    },
-  }
 }
 </script>
 

--- a/app/javascript/pages/mypage/index.vue
+++ b/app/javascript/pages/mypage/index.vue
@@ -18,17 +18,6 @@
         Myご縁箱をシェアする
       </v-btn>
     </v-col>
-    <v-col class="text-center mb-12">
-      <v-btn
-        color="grey"
-        class="white--text"
-        rounded
-        x-large
-        href="http://127.0.0.1:3000/users/2"
-      >
-        ユーザーページリンク
-      </v-btn>
-    </v-col>
     <transition name="fade">
       <ShareLinkModal
         :is-visible-share-link-modal="isVisibleShareLinkModal"
@@ -37,6 +26,8 @@
     </transition>
     <LetterListTab
       :user="user"
+      :letter-items="receivedLetters"
+      :sent-letters="sentLetters"
     />
   </v-container>
 </template>
@@ -59,6 +50,7 @@ export default {
     return {
       user: {},
       receivedLetters: [],
+      sentLetters: [],
       isVisibleShareLinkModal: false,
     };
   },
@@ -67,11 +59,12 @@ export default {
     ...mapGetters({ currentUser: "users/currentUser" }),
   },
   mounted() {
-    this.fetchReceivedLetters(),
     this.$axios.get("users/me")
     .then((res) => {
       this.user = res.data
       this.$store.commit('users/setCurrentUser', res.data)
+      this.fetchReceivedLetters(),
+      this.fetchSentLetters()
     })
   },
   methods: {
@@ -82,9 +75,15 @@ export default {
       this.isVisibleShareLinkModal = false;
     },
     async fetchReceivedLetters() {
-      await axios.get(`users/${this.currentUser.id}/received_letters`)
+      await axios.get(`/api/users/${this.currentUser.id}/received_letters`)
         .then((res) => {
           this.receivedLetters = res.data
+        })
+    },
+    async fetchSentLetters() {
+      await axios.get(`/api/users/${this.currentUser.id}/sent_letters`)
+        .then((res) => {
+          this.sentLetters = res.data
         })
     },
   }

--- a/app/javascript/pages/user/index.vue
+++ b/app/javascript/pages/user/index.vue
@@ -36,7 +36,7 @@
         v-if="isShow"
         :is-visible-create-letter-modal="isVisibleCreateLetterModal"
         :user="user"
-        @create-letter="createLetter"
+        @create-letter="fetchReceivedLetters"
         @close-modal="handleCloseCreateLetterModal"
       />
     </transition>
@@ -49,6 +49,7 @@
       v-if="isShow"
       :user="user"
       :letter-items="receivedLetters"
+      :sent-letters="sentLetters"
     />
   </v-container>
 </template>
@@ -77,12 +78,14 @@ export default {
       isShow: false,
       user: {},
       receivedLetters: [],
+      sentLetters: [],
       isVisibleCreateLetterModal: false,
     };
   },
   mounted() {
     this.fetchUser()
     this.fetchReceivedLetters()
+    this.fetchSentLetters()
   },
   computed: {
     ...mapGetters("users", ["currentUser"]),
@@ -99,7 +102,6 @@ export default {
       await axios.get(`/api/users/${this.$route.params.id}/received_letters`)
         .then((res) => {
           this.receivedLetters = res.data
-          console.log(this.receivedLetters); // リスト表示したレターの投稿主（user）の名前などの情報も渡したい。
         })
     },
     async fetchSentLetters() {
@@ -113,11 +115,8 @@ export default {
     },
     handleCloseCreateLetterModal() {
       this.isVisibleCreateLetterModal = false;
-    },
-    createLetter(letter) {
-      this.receivedLetters.push(letter);
-    },
-  }
+    }
+  },
 };
 </script>
 


### PR DESCRIPTION
## 概要

- 受け取ったレターリスト、送ったレターリストを作成

- ユーザーページ、マイページにそれぞれ正常にリスト表示

- LetterListTabコンポーネント内の受け取ったレター、送ったレターを押すと
  コンポーネントがそれぞれ切り替わること。

- receiverとsenderそれぞれのユーザーの情報を表示させること
（アイコン画像、名前、TwitterID）