### PR TITLE
レター削除機能

### DIFF
--- a/app/controllers/api/letters_controller.rb
+++ b/app/controllers/api/letters_controller.rb
@@ -39,7 +39,7 @@ class Api::LettersController < ApplicationController
 
   private
   def set_letter
-    @letter = current_user.letters.find(params[:id])
+    @letter = current_user.receivers.find(params[:id])
   end
 
   def letter_params

--- a/app/javascript/pages/components/LetterListReceived.vue
+++ b/app/javascript/pages/components/LetterListReceived.vue
@@ -59,6 +59,16 @@
                   <v-icon>mdi-twitter</v-icon>
                   シェア
                 </v-btn>
+                <v-btn
+                  v-if="isCurrentMypage"
+                  tile
+                  small
+                  color="brown darken-1"
+                  dark
+                  @click="hundleDeleteLetter(letterItem)"
+                >
+                  <v-icon> mdi-delete </v-icon>
+                </v-btn>
               </v-row>
             </v-card>
           </v-row>
@@ -105,6 +115,9 @@ export default {
     twitterUrl() {
       return `https://twitter.com/${this.currentUser.twitter_id}`
     },
+    isCurrentMypage() {
+      return this.$route.path === '/mypage'
+    }
   },
   methods: {
     openShareLetterModal() {
@@ -113,6 +126,20 @@ export default {
     handleCloseShareLetterModal() {
       this.isVisibleShareLetterModal = false;
     },
+    hundleDeleteLetter(letterItem) {
+      if (!confirm("削除してよろしいですか?")) return;
+      this.deleteLetter(letterItem);
+      this.$store.dispatch("flash/setFlash", {
+        type: "success",
+        message: "レターを削除しました。",
+      });
+    },
+    deleteLetter(letterItem) {
+      axios
+        .delete(`/api/letters/${letterItem.letter.id}`)
+        .then(() => this.$emit("delete-letter"));
+    },
+
   },
 };
 </script>

--- a/app/javascript/pages/components/LetterListTab.vue
+++ b/app/javascript/pages/components/LetterListTab.vue
@@ -28,6 +28,7 @@
             :user="user"
             :letter-items="letterItems"
             :sent-letters="sentLetters"
+            @delete-letter="deleteLetter"
           />
         </v-tab-item>
       </v-tabs-items>
@@ -67,6 +68,11 @@ export default {
       ]
     }
   },
+  methods: {
+    deleteLetter() {
+      this.$emit("delete-letter");
+    },
+  }
 }
 </script>
 

--- a/app/javascript/pages/mypage/index.vue
+++ b/app/javascript/pages/mypage/index.vue
@@ -28,6 +28,7 @@
       :user="user"
       :letter-items="receivedLetters"
       :sent-letters="sentLetters"
+      @delete-letter="fetchReceivedLetters"
     />
   </v-container>
 </template>


### PR DESCRIPTION
## 概要
- 削除ボタンを押すとレターが非同期で削除されること。

- ボタンをマイページでのみ表示されるように条件式とcomputedを設定。
（ユーザーページで見れないようにする）

