### PR TITLE
ユーザーページ間の遷移ができない

### DIFF
--- a/app/javascript/pages/user/index.vue
+++ b/app/javascript/pages/user/index.vue
@@ -89,6 +89,9 @@ export default {
   },
   computed: {
     ...mapGetters("users", ["currentUser"]),
+    currentPath() {
+      return this.$route.path
+    }
   },
   methods: {
     async fetchUser() {
@@ -115,6 +118,13 @@ export default {
     },
     handleCloseCreateLetterModal() {
       this.isVisibleCreateLetterModal = false;
+    }
+  },
+  watch: {
+    currentPath: function() {
+      this.fetchUser()
+      this.fetchReceivedLetters()
+      this.fetchSentLetters()
     }
   },
 };


### PR DESCRIPTION
## 概要
ユーザーページから別のユーザーページに遷移できない（URLが切り替わるだけ）問題。

動的ルートマッチングでは コンポーネントの再利用をおこなうため、ライフサイクルフックが呼ばれない 。

URLが切り替わった際に再度メソッドを実行してコンポーネントを切り替えることでひとまず解消。