### PR TITLE
レター作成機能（テキストエリアの表示切り替え）

### DIFF
--- a/app/javascript/pages/components/CreateLetterModal.vue
+++ b/app/javascript/pages/components/CreateLetterModal.vue
@@ -6,79 +6,40 @@
   >
     <v-card color="amber lighten-5">
       <v-card-title>
-        <span class="text-h5 my-5">ファンレター作成</span>
+        <v-icon>mdi-email-edit-outline</v-icon>
+        <span>ファンレター作成</span>
       </v-card-title>
       <v-divider />
-      <!-- // フォーム全体をHTML要素で統括 -->
+      <!-- フォーム全体をHTML要素で統括 -->
       <div
         id="create-letter-form"
         class="pa-10"
       >
         <!-- formタグでフォームデータを一括管理 -->
         <v-form @submit.prevent="handleCreateLetter(letter)">
-          <div class="mt-5">
-            <label
-              for="past"
-            >出会いのきっかけ・当時の印象</label>
-            <ShowTextareaButton
-              v-show="isShowThisButton"
-              :is-show-textarea="isShowTextarea"
-              :is-show-this-button="isShowThisButton"
-              @show-textarea="handleShowTextarea"
-            />
-            <v-textarea
-              v-show="isShowTextarea"
-              id="past"
-              v-model="letter.past"
-              name="create_letter[past]"
-              background-color="white"
-            />
-          </div>
-          <!-- フォーム内の１要素の区切り目 -->
-          <div class="mt-5">
-            <label
-              for="current"
-            >現在の印象・どんな人？</label>
-            <v-textarea
-              id="current"
-              v-model="letter.current"
-              name="create_letter[current]"
-              background-color="white"
-            />
-          </div>
-          <div class="mt-5">
-            <label
-              for="future"
-            >聞いてみたいこと／これから話してみたいこと</label>
-            <v-textarea
-              id="future"
-              v-model="letter.future"
-              name="create_letter[future]"
-              background-color="white"
-            />
-          </div>
-          <div class="mt-5">
-            <label
-              for="expect"
-            >{{ user.name }}さんに期待していること</label>
-            <v-textarea
-              id="expect"
-              v-model="letter.expect"
-              name="create_letter[expect]"
-              type="text"
-              background-color="white"
-            />
-          </div>
-          <div class="mt-5">
-            <label
-              for="message"
-            >メッセージ</label>
-            <v-textarea
-              id="message"
-              v-model="letter.message"
-              name="create_letter[message]"
-              background-color="white"
-            />
+          <div v-for="(letterTitle, index) in letterTitles()" :key="index">
+            <div class="mt-5">
+              <label
+                for="past"
+              >{{ letterTitle.message }}</label>
+              <v-card-actions class="justify-center">
+                <v-btn
+                  v-if="!ShowTextarea.includes(index)"
+                  @click="addShowTextarea(index)"
+                  color="deep-purple lighten-5"
+                >
+                  <v-icon>mdi-pencil</v-icon>
+                  書いてみる
+                </v-btn>
+              </v-card-actions>
+              <v-textarea
+                v-show="ShowTextarea.includes(index)"
+                :id="`${letterTitle.model_name}`"
+                v-model="letter[letterTitle.model_name]"
+                :name="`create_letter[${letterTitle.model_name}]`"
+                background-color="white"
+              />
+            </div>
           </div>
           <!-- 登録ボタン -->
           <v-row
@@ -112,13 +73,10 @@
 <script>
 import axios from "axios";
 import { mapGetters } from "vuex";
-import ShowTextareaButton from "./ShowTextareaButton";
 
 export default {
   name: "CreateLetterModal",
-  components: {
-    ShowTextareaButton,
-  },
+
   props: {
     isVisibleCreateLetterModal: {
       type: Boolean,
@@ -142,6 +100,7 @@ export default {
       },
       isShowTextarea: false,
       isShowThisButton: true,
+      ShowTextarea: []
     }
 
   },
@@ -149,6 +108,18 @@ export default {
     ...mapGetters("users", ["currentUser"]),
   },
   methods: {
+    letterTitles() {
+      return [
+        { message: '出会いのきっかけ・当時の印象', model_name: 'past' },
+        { message: '現在の印象・どんな人？', model_name: 'current' },
+        { message: '聞いてみたいこと／これから話してみたいこと', model_name: 'future' },
+        { message: `${this.user.name}さんに期待していること`, model_name: 'expect' },
+        { message: 'メッセージ', model_name: 'message' }
+      ]
+    },
+    addShowTextarea(index) {
+      this.ShowTextarea.push(index)
+    },
     handleCloseModal() {
       this.$emit("close-modal");
     },
@@ -172,7 +143,9 @@ export default {
 .modal {
   display: block;
 }
-.letter-item-input {
-  color: rgb(27, 21, 21)
+.title {
+  font-size: 1.6rem;
+  font-weight: bold;
+  color: #2e1f1f;
 }
 </style>

--- a/app/javascript/pages/user/index.vue
+++ b/app/javascript/pages/user/index.vue
@@ -17,6 +17,7 @@
     <v-row class="justify-center mb-4">
       <v-col align="center">
         <v-btn
+          v-if="this.currentUser"
           color="blue"
           class="white--text"
           rounded


### PR DESCRIPTION
## 概要

- レター作成モーダル内でテキストエリアをデフォルトで非表示にし、
書いてみるボタンを押すと表示させる。

- レター作成モーダルをログインしていない場合はボタンを表示しないように修正