### PR TITLE
プロフィールカードのレイアウト、アイコンURLの修正

### DIFF
--- a/app/javascript/pages/components/CreateLetterModal.vue
+++ b/app/javascript/pages/components/CreateLetterModal.vue
@@ -1,24 +1,20 @@
 <template>
   <v-dialog
     v-model="isVisibleCreateLetterModal"
-    max-width="600"
+    max-width="850"
     persistent
   >
     <v-card color="amber lighten-5">
       <v-card-title>
-        <v-icon>mdi-email-edit-outline</v-icon>
-        <span>ファンレター作成</span>
+        <span class="pa-8 l-font">ファンレター作成</span>
       </v-card-title>
       <v-divider />
       <!-- フォーム全体をHTML要素で統括 -->
-      <div
-        id="create-letter-form"
-        class="pa-10"
-      >
+      <div class="pa-10">
         <!-- formタグでフォームデータを一括管理 -->
         <v-form @submit.prevent="handleCreateLetter(letter)">
           <div v-for="(letterTitle, index) in letterTitles()" :key="index">
-            <div class="mt-5">
+            <div class="mt-8 m-font">
               <label
                 for="past"
               >{{ letterTitle.message }}</label>
@@ -27,18 +23,22 @@
                   v-if="!ShowTextarea.includes(index)"
                   @click="addShowTextarea(index)"
                   color="deep-purple lighten-5"
+                  class="mt-4"
                 >
                   <v-icon>mdi-pencil</v-icon>
                   書いてみる
                 </v-btn>
               </v-card-actions>
-              <v-textarea
-                v-show="ShowTextarea.includes(index)"
-                :id="`${letterTitle.model_name}`"
-                v-model="letter[letterTitle.model_name]"
-                :name="`create_letter[${letterTitle.model_name}]`"
-                background-color="white"
-              />
+              <v-col align="center">
+                <v-textarea
+                  v-show="ShowTextarea.includes(index)"
+                  :id="`${letterTitle.model_name}`"
+                  v-model="letter[letterTitle.model_name]"
+                  :name="`create_letter[${letterTitle.model_name}]`"
+                  background-color="white"
+                  class="textarea-style"
+                />
+              </v-col>
             </div>
           </div>
           <!-- 登録ボタン -->
@@ -143,9 +143,25 @@ export default {
 .modal {
   display: block;
 }
-.title {
-  font-size: 1.6rem;
+.l-font{
+  font-size: 1.8em;
   font-weight: bold;
-  color: #2e1f1f;
+  color: #2c281e;
+}
+.m-font{
+  font-size: 1.2em;
+  font-weight: bold;
+  color: #2c281e;
+}
+.s-font{
+  font-size: 1.1em;
+  font-weight: bold;
+  line-height: 1;
+  color: #2c281e;
+}
+.textarea-style{
+  line-height: 1.7;
+  font-size:1.2em;
+  width: 90%;
 }
 </style>

--- a/app/javascript/pages/components/ProfileCard.vue
+++ b/app/javascript/pages/components/ProfileCard.vue
@@ -1,12 +1,12 @@
 <template>
-  <v-row justify="center" class="mt-8">
+  <v-row justify="center" class="mt-12">
     <v-card
       color="transparent"
-      width="750px"
+      width="800px"
       class="ma-12"
     >
-      <v-card-title class="pa-8 mt-12">
-        <v-list-item-avatar size="120" class="avatar-position">
+      <v-card-title class="pa-8 mt-16">
+        <v-list-item-avatar size="150" class="avatar-position">
           <img :src="currentUser.image">
         </v-list-item-avatar>
         <v-list-item-content>
@@ -23,7 +23,7 @@
           </v-list-item-subtitle>
         </v-list-item-content>
       </v-card-title>
-      <v-card-text class="s-font px-8 mb-8">
+      <v-card-text class="m-font px-8 mb-8">
         {{ currentUser.introduce }}
       </v-card-text>
     </v-card>
@@ -46,13 +46,15 @@ export default {
 
 <style scoped>
 .l-font{
-  font-size: 1.8em;
+  font-size: 2.0em;
   font-weight: bold;
+  line-height: 1.5;
   color: #2c281e;
 }
 .m-font{
   font-size: 1.2em;
   font-weight: bold;
+  line-height: 1.3;
   color: #2c281e;
 }
 .s-font{
@@ -64,6 +66,6 @@ export default {
 .avatar-position {
   position: absolute;
   top: -60px;
-  left: 20px;
+  left: 30px;
 }
 </style>

--- a/app/javascript/pages/components/ProfileCard.vue
+++ b/app/javascript/pages/components/ProfileCard.vue
@@ -1,47 +1,33 @@
 <template>
-  <v-card
-    color="#fff6e4"
-    width="500px"
-  >
-    <v-card-title>
-      <v-list-item-avatar size="50">
-        <img :src="currentUser.image">
-      </v-list-item-avatar>
-      <v-list-item-content>
-        <v-list-item-title>{{ currentUser.name }}</v-list-item-title>
-        <v-list-item-subtitle>
-          @{{ currentUser.twitter_id }}
-          <v-btn
-            icon
-            color="blue"
-            :href="twitterUrl"
-          >
-            <v-icon>mdi-twitter</v-icon>
-          </v-btn>
-        </v-list-item-subtitle>
-      </v-list-item-content>
-    </v-card-title>
-    <v-card-text>
-      {{ currentUser.introduce }}
-    </v-card-text>
-
-    <v-card-actions>
-      <v-list-item class="grow">
+  <v-row justify="center" class="mt-8">
+    <v-card
+      color="transparent"
+      width="750px"
+      class="ma-12"
+    >
+      <v-card-title class="pa-8 mt-12">
+        <v-list-item-avatar size="120" class="avatar-position">
+          <img :src="currentUser.image">
+        </v-list-item-avatar>
         <v-list-item-content>
-          <v-list-item-title>書いたレター</v-list-item-title>
+          <p class="l-font">{{ currentUser.name }}</p>
+          <v-list-item-subtitle class="s-font mt-3">
+            @{{ currentUser.twitter_id }}
+            <v-btn
+              icon
+              color="blue"
+              :href="twitterUrl"
+            >
+              <v-icon>mdi-twitter</v-icon>
+            </v-btn>
+          </v-list-item-subtitle>
         </v-list-item-content>
-        <v-row
-          align="center"
-          justify="end"
-        >
-          <v-icon class="mr-1">
-            mdi-pencil
-          </v-icon>
-          <span class="subheading mr-2">256</span>
-        </v-row>
-      </v-list-item>
-    </v-card-actions>
-  </v-card>
+      </v-card-title>
+      <v-card-text class="s-font px-8 mb-8">
+        {{ currentUser.introduce }}
+      </v-card-text>
+    </v-card>
+  </v-row>
 </template>
 
 <script>
@@ -57,3 +43,27 @@ export default {
   },
 }
 </script>
+
+<style scoped>
+.l-font{
+  font-size: 1.8em;
+  font-weight: bold;
+  color: #2c281e;
+}
+.m-font{
+  font-size: 1.2em;
+  font-weight: bold;
+  color: #2c281e;
+}
+.s-font{
+  font-size: 1.1em;
+  font-weight: bold;
+  line-height: 1;
+  color: #2c281e;
+}
+.avatar-position {
+  position: absolute;
+  top: -60px;
+  left: 20px;
+}
+</style>

--- a/app/javascript/pages/components/UserProfileCard.vue
+++ b/app/javascript/pages/components/UserProfileCard.vue
@@ -1,49 +1,33 @@
 <template>
-  <v-card
-    color="amber lighten-5"
-    width="500px"
-  >
-    <v-card-title>
-      <v-list-item-avatar size="50">
-        <img :src="user.image">
-      </v-list-item-avatar>
-
-      <v-list-item-content>
-        <v-list-item-title>{{ user.name }}</v-list-item-title>
-        <v-list-item-subtitle>
-          @{{ user.twitter_id }}
-          <v-btn
-            icon
-            color="blue"
-            :href="twitterUrl"
-          >
-            <v-icon>mdi-twitter</v-icon>
-          </v-btn>
-        </v-list-item-subtitle>
-      </v-list-item-content>
-    </v-card-title>
-
-    <v-card-text>
-      {{ user.introduce }}
-    </v-card-text>
-
-    <v-card-actions>
-      <v-list-item class="grow">
+  <v-row justify="center" class="mt-8">
+    <v-card
+      color="transparent"
+      width="750px"
+      class="ma-12"
+    >
+      <v-card-title class="pa-8 mt-12">
+        <v-list-item-avatar  size="120" class="avatar-position">
+          <img :src="user.image">
+        </v-list-item-avatar>
         <v-list-item-content>
-          <v-list-item-title>書いたレター</v-list-item-title>
+          <p class="l-font">{{ user.name }}</p>
+          <v-list-item-subtitle class="s-font mt-3">
+            @{{ user.twitter_id }}
+            <v-btn
+              icon
+              color="blue"
+              :href="twitterUrl"
+            >
+              <v-icon>mdi-twitter</v-icon>
+            </v-btn>
+          </v-list-item-subtitle>
         </v-list-item-content>
-        <v-row
-          align="center"
-          justify="end"
-        >
-          <v-icon class="mr-1">
-            mdi-pencil
-          </v-icon>
-          <span class="subheading mr-2">256</span>
-        </v-row>
-      </v-list-item>
-    </v-card-actions>
-  </v-card>
+      </v-card-title>
+      <v-card-text class="s-font px-8 mb-8">
+        {{ user.introduce }}
+      </v-card-text>
+    </v-card>
+  </v-row>
 </template>
 
 <script>
@@ -63,3 +47,26 @@ export default {
   },
 }
 </script>
+<style scoped>
+.l-font{
+  font-size: 1.8em;
+  font-weight: bold;
+  color: #2c281e;
+}
+.m-font{
+  font-size: 1.2em;
+  font-weight: bold;
+  color: #2c281e;
+}
+.s-font{
+  font-size: 1.1em;
+  font-weight: bold;
+  line-height: 1;
+  color: #2c281e;
+}
+.avatar-position {
+  position: absolute;
+  top: -60px;
+  left: 20px;
+}
+</style>

--- a/app/javascript/pages/components/UserProfileCard.vue
+++ b/app/javascript/pages/components/UserProfileCard.vue
@@ -1,12 +1,12 @@
 <template>
-  <v-row justify="center" class="mt-8">
+  <v-row justify="center" class="mt-12">
     <v-card
       color="transparent"
-      width="750px"
+      width="800px"
       class="ma-12"
     >
-      <v-card-title class="pa-8 mt-12">
-        <v-list-item-avatar  size="120" class="avatar-position">
+      <v-card-title class="pa-8 mt-16">
+        <v-list-item-avatar  size="150" class="avatar-position">
           <img :src="user.image">
         </v-list-item-avatar>
         <v-list-item-content>
@@ -23,7 +23,7 @@
           </v-list-item-subtitle>
         </v-list-item-content>
       </v-card-title>
-      <v-card-text class="s-font px-8 mb-8">
+      <v-card-text class="m-font px-8 mb-8">
         {{ user.introduce }}
       </v-card-text>
     </v-card>
@@ -49,13 +49,15 @@ export default {
 </script>
 <style scoped>
 .l-font{
-  font-size: 1.8em;
+  font-size: 2.0em;
   font-weight: bold;
+  line-height: 1.5;
   color: #2c281e;
 }
 .m-font{
   font-size: 1.2em;
   font-weight: bold;
+  line-height: 1.3;
   color: #2c281e;
 }
 .s-font{
@@ -67,6 +69,6 @@ export default {
 .avatar-position {
   position: absolute;
   top: -60px;
-  left: 20px;
+  left: 30px;
 }
 </style>

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  before_save :modify_avatar_url
   authenticates_with_sorcery!
 
   has_many :authentications, dependent: :destroy
@@ -16,7 +17,9 @@ class User < ApplicationRecord
   validates :introduce, length: { maximum: 300 }
   validates :role, presence: true
 
-  def modify_avater_url
-    avatar_url&.sub!('_normal.jpg', '.jpg')
+  private
+
+  def modify_avatar_url
+    avatar_url&.sub!(/_normal(.jpg|.jpeg|.gif|.png)/i) { Regexp.last_match[1] }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,4 +15,8 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 50 }
   validates :introduce, length: { maximum: 300 }
   validates :role, presence: true
+
+  def modify_avater_url
+    avatar_url&.sub!('_normal.jpg', '.jpg')
+  end
 end


### PR DESCRIPTION
## 概要
- Twitterから取得したアバター画像の画質が悪い点を改善
Twitterドキュメント
http://westplain.sakuraweb.com/translate/twitter/Best-Practices/Profile-Images-and-Banners.cgi

Twitterから取得できるアイコン画像のURLは４種類あり、デフォルトだと48pxの画像を取得してしまうため画質が落ちる。

サイズ指定の部分の文字列"_nomal.png"を取り除きたい。
デフォルトサイズ（画質が粗い）
```
http://pbs.twimg.com/profile_images/2284174872/7df3h38zabcvjylnyfe3_normal.png
```
オリジナルサイズ（こちらを取得したい）
```
http://pbs.twimg.com/profile_images/2284174872/7df3h38zabcvjylnyfe3.png
```
該当する文字列を取り除くsub!メソッド　を使用して第一引数に該当する文字列を削除する。
https://docs.ruby-lang.org/ja/latest/method/String/i/sub.html


- プロフィールカードのレイアウト調節
- レター作成モーダルのレイアウト微調節