### PR TITLE
レター編集機能の実装

### DIFF
--- a/app/controllers/api/letters_controller.rb
+++ b/app/controllers/api/letters_controller.rb
@@ -1,10 +1,6 @@
 class Api::LettersController < ApplicationController
   skip_before_action :verify_authenticity_token
-  before_action :set_letter, only: [:edit, :update, :destroy]
-
-  def show
-    render json: @letter
-  end
+  before_action :set_letter, only: [:update, :destroy]
 
   def create
     @letter = current_user.letters.build(letter_params)
@@ -13,10 +9,6 @@ class Api::LettersController < ApplicationController
     else
       render json: @letter.errors, status: :bad_request
     end
-  end
-
-  def edit
-    @letter = current_user.find(params[:id])
   end
 
   def update
@@ -32,14 +24,9 @@ class Api::LettersController < ApplicationController
     render json: @letter
   end
 
-  def my_sent_letter
-    @sent_letter = current_user.sent_letters
-    render json: @sent_letter
-  end
-
   private
   def set_letter
-    @letter = current_user.letters.find(params[:id])
+    @letter = current_user.letters.find_by(id: params[:id]) || current_user.receivers.find_by(id: params[:id])
   end
 
   def letter_params

--- a/app/controllers/api/letters_controller.rb
+++ b/app/controllers/api/letters_controller.rb
@@ -39,7 +39,7 @@ class Api::LettersController < ApplicationController
 
   private
   def set_letter
-    @letter = current_user.receivers.find(params[:id])
+    @letter = current_user.letters.find(params[:id])
   end
 
   def letter_params

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -2,7 +2,7 @@ class Api::UsersController < ApplicationController
 
   def sent_letters
     user = User.find(params[:id])
-    @sent_letters = user.letters
+    @sent_letters = user.letters.order(created_at: :desc)
     sent_letters = @sent_letters.map do |letter|
       {
         letter: letter,
@@ -15,7 +15,7 @@ class Api::UsersController < ApplicationController
 
   def received_letters
     user = User.find(params[:id])
-    @received_letters = user.receivers
+    @received_letters = user.receivers.order(created_at: :desc)
     received_letters = @received_letters.map do |letter|
       {
         letter: letter,

--- a/app/javascript/pages/components/EditLetterModal.vue
+++ b/app/javascript/pages/components/EditLetterModal.vue
@@ -2,7 +2,6 @@
   <v-dialog
     v-model="isVisibleEditLetterModal"
     max-width="850"
-    scrollable
     persistent
   >
     <v-card color="amber lighten-5">
@@ -26,7 +25,6 @@
                   :name="`update_letter[${letterTitle.model_name}]`"
                   background-color="white"
                   class="textarea-style"
-                  auto-grow
                   rows="4"
                 />
               </v-col>
@@ -86,7 +84,6 @@ export default {
     return {
       letter: this.updateLetter,
     }
-
   },
   computed: {
     ...mapGetters("users", ["currentUser"]),
@@ -140,6 +137,7 @@ export default {
 }
 .textarea-style{
   line-height: 1.7;
+  letter-spacing: 20px;
   font-size:1.2em;
   width: 90%;
 }

--- a/app/javascript/pages/components/EditLetterModal.vue
+++ b/app/javascript/pages/components/EditLetterModal.vue
@@ -15,7 +15,7 @@
             <div class="mt-8 m-font">
               <label
                 for="past"
-              >{{ letterTitle.message }}</label>
+              >{{ letterTitle.item }}</label>
               <v-col align="center">
                 <v-textarea
                   :id="`${letterTitle.model_name}`"
@@ -103,11 +103,11 @@ export default {
   methods: {
     letterTitles() {
       return [
-        { message: '出会いのきっかけ・当時の印象', model_name: 'past' },
-        { message: '現在の印象・どんな人？', model_name: 'current' },
-        { message: '聞いてみたいこと／これから話してみたいこと', model_name: 'future' },
-        { message: `${this.user.name}さんに期待していること`, model_name: 'expect' },
-        { message: 'メッセージ', model_name: 'message' }
+        { item: '出会いのきっかけ・当時の印象', model_name: 'past' },
+        { item: '現在の印象・どんな人？', model_name: 'current' },
+        { item: '聞いてみたいこと／これから話してみたいこと', model_name: 'future' },
+        { item: `${this.user.name}さんに期待していること`, model_name: 'expect' },
+        { item: 'メッセージ', model_name: 'message' }
       ]
     },
     handleCloseModal() {

--- a/app/javascript/pages/components/EditLetterModal.vue
+++ b/app/javascript/pages/components/EditLetterModal.vue
@@ -9,10 +9,8 @@
         <span class="pa-8 l-font">レターの更新</span>
       </v-card-title>
       <v-divider />
-      <!-- フォーム全体をHTML要素で統括 -->
       <div class="pa-10">
-        <!-- formタグでフォームデータを一括管理 -->
-        <v-form @submit.prevent="handleUpdateLetter(updateLetter)">
+        <v-form @submit.prevent="handleUpdateLetter(letter)">
           <div v-for="(letterTitle, index) in letterTitles()" :key="index">
             <div class="mt-8 m-font">
               <label
@@ -21,8 +19,8 @@
               <v-col align="center">
                 <v-textarea
                   :id="`${letterTitle.model_name}`"
-                  v-model="updateLetter[letterTitle.model_name]"
-                  :name="`update_letter[${letterTitle.model_name}]`"
+                  v-model="letter[letterTitle.model_name]"
+                  :name="`letter[${letterTitle.model_name}]`"
                   background-color="white"
                   class="textarea-style"
                   rows="4"
@@ -77,12 +75,26 @@ export default {
     },
     updateLetter: {
       type: Object,
-      required: true
+      required: true,
+    }
+  },
+  computed: {
+    updateLetterItem() {
+      return this.updateLetter
     }
   },
   data() {
-    return {
-      letter: this.updateLetter,
+    return { // propsのオブジェクトをそのまま渡すと参照渡しとなり、propsと連動してしまい、モーダルの外の値が変わってしまう。
+      letter: {
+        id: this.updateLetter.id,
+        sender_id: this.updateLetter.sender_id,
+        receiver_id: this.updateLetter.receiver_id,
+        past: this.updateLetter.past,
+        current: this.updateLetter.current,
+        future: this.updateLetter.future,
+        expect: this.updateLetter.expect,
+        message: this.updateLetter.message
+      }
     }
   },
   computed: {

--- a/app/javascript/pages/components/EditLetterModal.vue
+++ b/app/javascript/pages/components/EditLetterModal.vue
@@ -1,0 +1,146 @@
+<template>
+  <v-dialog
+    v-model="isVisibleEditLetterModal"
+    max-width="850"
+    scrollable
+    persistent
+  >
+    <v-card color="amber lighten-5">
+      <v-card-title>
+        <span class="pa-8 l-font">レターの更新</span>
+      </v-card-title>
+      <v-divider />
+      <!-- フォーム全体をHTML要素で統括 -->
+      <div class="pa-10">
+        <!-- formタグでフォームデータを一括管理 -->
+        <v-form @submit.prevent="handleUpdateLetter(updateLetter)">
+          <div v-for="(letterTitle, index) in letterTitles()" :key="index">
+            <div class="mt-8 m-font">
+              <label
+                for="past"
+              >{{ letterTitle.message }}</label>
+              <v-col align="center">
+                <v-textarea
+                  :id="`${letterTitle.model_name}`"
+                  v-model="updateLetter[letterTitle.model_name]"
+                  :name="`update_letter[${letterTitle.model_name}]`"
+                  background-color="white"
+                  class="textarea-style"
+                  auto-grow
+                  rows="4"
+                />
+              </v-col>
+            </div>
+          </div>
+          <!-- 登録ボタン -->
+          <v-row
+            justify="center"
+            class="ma-8"
+          >
+            <v-card-actions>
+              <v-btn
+                type="submit"
+                elevation="4"
+                x-large
+                color="blue"
+                class="white--text"
+              >
+                更新する
+              </v-btn>
+              <v-btn
+                large
+                @click="handleCloseModal"
+              >
+                閉じる
+              </v-btn>
+            </v-card-actions>
+          </v-row>
+        </v-form>
+      </div>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import axios from "axios";
+import { mapGetters } from "vuex";
+
+export default {
+  name: "EditLetterModal",
+
+  props: {
+    isVisibleEditLetterModal: {
+      type: Boolean,
+      required: true,
+    },
+    user: {
+      type: Object,
+      required: true
+    },
+    updateLetter: {
+      type: Object,
+      required: true
+    }
+  },
+  data() {
+    return {
+      letter: this.updateLetter,
+    }
+
+  },
+  computed: {
+    ...mapGetters("users", ["currentUser"]),
+  },
+  methods: {
+    letterTitles() {
+      return [
+        { message: '出会いのきっかけ・当時の印象', model_name: 'past' },
+        { message: '現在の印象・どんな人？', model_name: 'current' },
+        { message: '聞いてみたいこと／これから話してみたいこと', model_name: 'future' },
+        { message: `${this.user.name}さんに期待していること`, model_name: 'expect' },
+        { message: 'メッセージ', model_name: 'message' }
+      ]
+    },
+    handleCloseModal() {
+      this.$emit("close-modal");
+    },
+    handleUpdateLetter() {
+      axios
+        .patch((`/api/letters/${this.letter.id}`), { letter: this.letter })
+        .then((res) => this.$emit("update-letter", res.data));
+        this.handleCloseModal();
+        this.$store.dispatch("flash/setFlash", {
+          type: "success",
+          message: "レターを編集しました。"
+        });
+    },
+  },
+};
+</script>
+
+<style scoped>
+.modal {
+  display: block;
+}
+.l-font{
+  font-size: 1.8em;
+  font-weight: bold;
+  color: #2c281e;
+}
+.m-font{
+  font-size: 1.2em;
+  font-weight: bold;
+  color: #2c281e;
+}
+.s-font{
+  font-size: 1.1em;
+  font-weight: bold;
+  line-height: 1;
+  color: #2c281e;
+}
+.textarea-style{
+  line-height: 1.7;
+  font-size:1.2em;
+  width: 90%;
+}
+</style>

--- a/app/javascript/pages/components/LetterItem.vue
+++ b/app/javascript/pages/components/LetterItem.vue
@@ -59,7 +59,7 @@ export default {
         {
           name: "message",
           title: "メッセージ",
-          text: this.letterItems.message
+          text: this.letterItems.letter.message
         }
       ]
       .filter(existsLetterItem => existsLetterItem.text)

--- a/app/javascript/pages/components/LetterItem.vue
+++ b/app/javascript/pages/components/LetterItem.vue
@@ -32,10 +32,6 @@ export default {
       type: Object,
       required: true
     },
-    sentLetters: {
-      type: Object,
-      required: true
-    }
   },
   computed: {
     createdLetter() {

--- a/app/javascript/pages/components/LetterListReceived.vue
+++ b/app/javascript/pages/components/LetterListReceived.vue
@@ -1,8 +1,8 @@
 <template>
   <v-container class="pa-0">
     <div
-      v-for="letterItem in letterItems"
-      :key="letterItem.id"
+      v-for="receivedLetter in receivedLetters"
+      :key="receivedLetter.id"
     >
       <v-card
         color="#FFFFF8"
@@ -20,21 +20,21 @@
               rounded="xl"
             >
               <v-card-title class="ps-16">
-                <router-link :to="{ name: 'UserIndex', params: { id: letterItem.sender.id }}">
+                <router-link :to="{ name: 'UserIndex', params: { id: receivedLetter.sender.id }}">
                   <v-list-item-avatar size="50">
-                    <img :src="letterItem.sender.image">
+                    <img :src="receivedLetter.sender.image">
                   </v-list-item-avatar>
                 </router-link>
                 <v-list-item-content>
                   <v-list-item-title class="font-bold">
-                    {{ letterItem.sender.name }}
+                    {{ receivedLetter.sender.name }}
                   </v-list-item-title>
                   <v-list-item-subtitle>
-                    @{{ letterItem.sender.twitter_id }}
+                    @{{ receivedLetter.sender.twitter_id }}
                     <v-btn
                       icon
                       color="blue"
-                      :href="`https://twitter.com/${letterItem.sender.twitter_id}`"
+                      :href="`https://twitter.com/${receivedLetter.sender.twitter_id}`"
                     >
                       <v-icon>mdi-twitter</v-icon>
                     </v-btn>
@@ -42,8 +42,7 @@
                 </v-list-item-content>
               </v-card-title>
               <LetterItem
-                :letter-items="letterItem"
-                :sent-letters="letterItem"
+                :letter-items="receivedLetter"
                 :user="user"
               />
               <v-row
@@ -66,7 +65,7 @@
                   small
                   color="brown darken-1"
                   dark
-                  @click="hundleDeleteLetter(letterItem)"
+                  @click="hundleDeleteLetter(receivedLetter)"
                 >
                   <v-icon> mdi-delete </v-icon>
                 </v-btn>
@@ -101,7 +100,7 @@ export default {
       type: Object,
       required: true
     },
-    letterItems: {
+    receivedLetters: {
       type: Array,
       required: true
     },
@@ -124,17 +123,17 @@ export default {
     handleCloseShareLetterModal() {
       this.isVisibleShareLetterModal = false;
     },
-    hundleDeleteLetter(letterItem) {
+    hundleDeleteLetter(receivedLetter) {
       if (!confirm("削除してよろしいですか?")) return;
-      this.deleteLetter(letterItem);
+      this.deleteLetter(receivedLetter);
       this.$store.dispatch("flash/setFlash", {
         type: "success",
         message: "レターを削除しました。",
       });
     },
-    deleteLetter(letterItem) {
+    deleteLetter(receivedLetter) {
       axios
-        .delete(`/api/letters/${letterItem.letter.id}`)
+        .delete(`/api/letters/${receivedLetter.letter.id}`)
         .then(() => this.$emit("delete-letter"));
     },
 

--- a/app/javascript/pages/components/LetterListSent.vue
+++ b/app/javascript/pages/components/LetterListSent.vue
@@ -36,25 +36,14 @@ export default {
     ...mapGetters({ currentUser: "users/currentUser" }),
   },
   methods: {
-
     openUpdateLetterModal() {
       this.isVisibleUpdateLetterModal = true;
     },
     handleCloseUpdateLetterModal() {
       this.isVisibleUpdateLetterModal = false;
     },
-    hundleDeleteLetter(sentLetters) {
-      if (!confirm("削除してよろしいですか?")) return;
-      this.deleteLetter(sentLetters);
-      this.$store.dispatch("flash/setFlash", {
-        type: "success",
-        message: "レターを削除しました。",
-      });
-    },
-    deleteLetter(letterItem) {
-      axios
-        .delete(`/api/letters/${letterItem.letter.id}`)
-        .then(() => this.$emit("delete-letter"));
+    deleteLetter() {
+      this.$emit("delete-letter");
     },
   },
 };

--- a/app/javascript/pages/components/LetterListSent.vue
+++ b/app/javascript/pages/components/LetterListSent.vue
@@ -50,8 +50,6 @@ export default {
         type: "success",
         message: "レターを削除しました。",
       });
-      // Error in v-on handler: "TypeError: Cannot read properties of undefined (reading 'id')"
-      // フラッシュメッセージの表示
     },
     deleteLetter(letterItem) {
       axios

--- a/app/javascript/pages/components/LetterListSent.vue
+++ b/app/javascript/pages/components/LetterListSent.vue
@@ -8,6 +8,7 @@
       <LetterListSentCard
         :user="user"
         :sentLetter="sentLetter"
+        @update-letter="handleUpdateLetter"
       />
     </div>
   </v-container>
@@ -45,6 +46,9 @@ export default {
     deleteLetter() {
       this.$emit("delete-letter");
     },
+    handleUpdateLetter() {
+      this.$emit("update-letter");
+    }
   },
 };
 </script>

--- a/app/javascript/pages/components/LetterListSentCard.vue
+++ b/app/javascript/pages/components/LetterListSentCard.vue
@@ -73,7 +73,6 @@
           :user="user"
           :updateLetter="sentLetter.letter"
           @close-modal="handleCloseEditLetterModal"
-
         />
       </transition>
     </v-card>

--- a/app/javascript/pages/components/LetterListSentCard.vue
+++ b/app/javascript/pages/components/LetterListSentCard.vue
@@ -1,0 +1,137 @@
+<template>
+  <v-container>
+      <v-card
+        color="#FFFFF8"
+        flat
+      >
+        <keep-alive>
+          <v-row
+            class="ma-8"
+            justify="center"
+          >
+            <v-card
+              flat
+              color="#f1f1f1"
+              width="800px"
+              rounded="xl"
+            >
+              <v-card-title class="ps-16">
+                <router-link :to="{ name: 'UserIndex', params: { id: sentLetter.receiver.id }}">
+                  <v-list-item-avatar size="50">
+                    <img :src="sentLetter.receiver.image">
+                  </v-list-item-avatar>
+                </router-link>
+                <v-list-item-content>
+                  <v-list-item-title class="font-bold">
+                    {{ sentLetter.receiver.name }}
+                  </v-list-item-title>
+                  <v-list-item-subtitle>
+                    @{{ sentLetter.receiver.twitter_id }}
+                    <v-btn
+                      icon
+                      color="blue"
+                      :href="`https://twitter.com/${sentLetter.receiver.twitter_id}`"
+                    >
+                      <v-icon>mdi-twitter</v-icon>
+                    </v-btn>
+                  </v-list-item-subtitle>
+                </v-list-item-content>
+              </v-card-title>
+              <LetterItem
+                :letter-items="sentLetter"
+                :user="user"
+              />
+              <v-row
+                justify="end"
+                class="ma-4"
+              >
+              </v-row>
+              <v-col class="text-center">
+                <v-btn
+                  color="blue"
+                  class="white--text"
+                  small
+                  @click="openEditLetterModal"
+                >
+                  <v-icon>mdi-pencil</v-icon>
+                  レターを修正する
+                </v-btn>
+                <v-btn
+                  color="indigo"
+                  class="white--text"
+                  small
+                  @click="hundleDeleteLetter(sentLetter)"
+                >削除
+                </v-btn>
+              </v-col>
+            </v-card>
+          </v-row>
+        </keep-alive>
+      <transition name="fade">
+        <EditLetterModal
+          :is-visible-edit-letter-modal="isVisibleEditLetterModal"
+          :user="user"
+          :updateLetter="sentLetter.letter"
+          @close-modal="handleCloseEditLetterModal"
+
+        />
+      </transition>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+import axios from "axios";
+import { mapGetters } from "vuex";
+import LetterItem from '../components/LetterItem';
+import EditLetterModal from "../components/EditLetterModal";
+
+export default {
+  components: {
+    LetterItem,
+    EditLetterModal
+  },
+  data() {
+    return {
+      isVisibleEditLetterModal: false,
+    }
+  },
+  props: {
+    user: {
+      type: Object,
+      required: true
+    },
+    sentLetter: {
+      type: Object,
+      required: true
+    },
+},
+  computed: {
+    ...mapGetters({ currentUser: "users/currentUser" }),
+  },
+  methods: {
+    openEditLetterModal() {
+      this.isVisibleEditLetterModal = true;
+    },
+    handleCloseEditLetterModal() {
+      this.isVisibleEditLetterModal = false;
+    },
+    hundleDeleteLetter(sentLetter) {
+      if (!confirm("削除してよろしいですか?")) return;
+      this.deleteLetter(sentLetter);
+      this.$store.dispatch("flash/setFlash", {
+        type: "success",
+        message: "レターを削除しました。"
+      });
+    },
+    deleteLetter(letterItem) {
+      axios
+        .delete(`/api/letters/${letterItem.letter.id}`)
+        .then(() => this.$emit("delete-letter"));
+    },
+  },
+};
+</script>
+
+<style scoped>
+</style>

--- a/app/javascript/pages/components/LetterListSentCard.vue
+++ b/app/javascript/pages/components/LetterListSentCard.vue
@@ -40,15 +40,15 @@
             :letter-items="sentLetter"
             :user="user"
           />
-          <v-col class="text-center">
+          <v-col v-if="isCurrentMypage" class="text-center">
             <v-btn
-              color="blue"
+              color="orange"
               class="white--text"
               small
               @click="openEditLetterModal"
             >
               <v-icon>mdi-pencil</v-icon>
-              レターを修正する
+              編集
             </v-btn>
             <v-btn
               color="indigo"
@@ -101,6 +101,9 @@ export default {
   },
   computed: {
     ...mapGetters({ currentUser: "users/currentUser" }),
+    isCurrentMypage() {
+      return this.$route.path === '/mypage'
+    }
   },
   methods: {
     openEditLetterModal() {

--- a/app/javascript/pages/components/LetterListSentCard.vue
+++ b/app/javascript/pages/components/LetterListSentCard.vue
@@ -1,82 +1,76 @@
 <template>
-  <v-container>
-      <v-card
-        color="#FFFFF8"
-        flat
+  <v-card
+    color="#FFFFF8"
+    flat
+  >
+    <keep-alive>
+      <v-row
+        class="ma-8"
+        justify="center"
       >
-        <keep-alive>
-          <v-row
-            class="ma-8"
-            justify="center"
-          >
-            <v-card
-              flat
-              color="#f1f1f1"
-              width="800px"
-              rounded="xl"
-            >
-              <v-card-title class="ps-16">
-                <router-link :to="{ name: 'UserIndex', params: { id: sentLetter.receiver.id }}">
-                  <v-list-item-avatar size="50">
-                    <img :src="sentLetter.receiver.image">
-                  </v-list-item-avatar>
-                </router-link>
-                <v-list-item-content>
-                  <v-list-item-title class="font-bold">
-                    {{ sentLetter.receiver.name }}
-                  </v-list-item-title>
-                  <v-list-item-subtitle>
-                    @{{ sentLetter.receiver.twitter_id }}
-                    <v-btn
-                      icon
-                      color="blue"
-                      :href="`https://twitter.com/${sentLetter.receiver.twitter_id}`"
-                    >
-                      <v-icon>mdi-twitter</v-icon>
-                    </v-btn>
-                  </v-list-item-subtitle>
-                </v-list-item-content>
-              </v-card-title>
-              <LetterItem
-                :letter-items="sentLetter"
-                :user="user"
-              />
-              <v-row
-                justify="end"
-                class="ma-4"
-              >
-              </v-row>
-              <v-col class="text-center">
+        <v-card
+          flat
+          color="#f1f1f1"
+          width="800px"
+          rounded="xl"
+        >
+          <v-card-title class="ps-16">
+            <router-link :to="{ name: 'UserIndex', params: { id: sentLetter.receiver.id }}">
+              <v-list-item-avatar size="50">
+                <img :src="sentLetter.receiver.image">
+              </v-list-item-avatar>
+            </router-link>
+            <v-list-item-content>
+              <v-list-item-title class="font-bold">
+                {{ sentLetter.receiver.name }}
+              </v-list-item-title>
+              <v-list-item-subtitle>
+                @{{ sentLetter.receiver.twitter_id }}
                 <v-btn
+                  icon
                   color="blue"
-                  class="white--text"
-                  small
-                  @click="openEditLetterModal"
+                  :href="`https://twitter.com/${sentLetter.receiver.twitter_id}`"
                 >
-                  <v-icon>mdi-pencil</v-icon>
-                  レターを修正する
+                  <v-icon>mdi-twitter</v-icon>
                 </v-btn>
-                <v-btn
-                  color="indigo"
-                  class="white--text"
-                  small
-                  @click="hundleDeleteLetter(sentLetter)"
-                >削除
-                </v-btn>
-              </v-col>
-            </v-card>
-          </v-row>
-        </keep-alive>
-      <transition name="fade">
-        <EditLetterModal
-          :is-visible-edit-letter-modal="isVisibleEditLetterModal"
-          :user="user"
-          :updateLetter="sentLetter.letter"
-          @close-modal="handleCloseEditLetterModal"
-        />
-      </transition>
-    </v-card>
-  </v-container>
+              </v-list-item-subtitle>
+            </v-list-item-content>
+          </v-card-title>
+          <LetterItem
+            :letter-items="sentLetter"
+            :user="user"
+          />
+          <v-col class="text-center">
+            <v-btn
+              color="blue"
+              class="white--text"
+              small
+              @click="openEditLetterModal"
+            >
+              <v-icon>mdi-pencil</v-icon>
+              レターを修正する
+            </v-btn>
+            <v-btn
+              color="indigo"
+              class="white--text"
+              small
+              @click="hundleDeleteLetter(sentLetter)"
+            >削除
+            </v-btn>
+          </v-col>
+        </v-card>
+      </v-row>
+    </keep-alive>
+    <transition name="fade">
+      <EditLetterModal
+        :is-visible-edit-letter-modal="isVisibleEditLetterModal"
+        :user="user"
+        :updateLetter="sentLetter.letter"
+        @close-modal="handleCloseEditLetterModal"
+        @update-letter="handleUpdateLetter"
+      />
+    </transition>
+  </v-card>
 </template>
 
 <script>
@@ -103,8 +97,8 @@ export default {
     sentLetter: {
       type: Object,
       required: true
-    },
-},
+    }
+  },
   computed: {
     ...mapGetters({ currentUser: "users/currentUser" }),
   },
@@ -128,6 +122,9 @@ export default {
         .delete(`/api/letters/${letterItem.letter.id}`)
         .then(() => this.$emit("delete-letter"));
     },
+    handleUpdateLetter() {
+      this.$emit("update-letter");
+    }
   },
 };
 </script>

--- a/app/javascript/pages/components/LetterListTab.vue
+++ b/app/javascript/pages/components/LetterListTab.vue
@@ -29,6 +29,7 @@
             :received-letters="receivedLetters"
             :sent-letters="sentLetters"
             @delete-letter="deleteLetter"
+            @update-letter="handleUpdateLetter"
           />
         </v-tab-item>
       </v-tabs-items>
@@ -72,6 +73,9 @@ export default {
     deleteLetter() {
       this.$emit("delete-letter");
     },
+    handleUpdateLetter() {
+      this.$emit("update-letter");
+    }
   }
 }
 </script>

--- a/app/javascript/pages/components/LetterListTab.vue
+++ b/app/javascript/pages/components/LetterListTab.vue
@@ -26,7 +26,7 @@
           <component
             :is="tabItem.content"
             :user="user"
-            :letter-items="letterItems"
+            :received-letters="receivedLetters"
             :sent-letters="sentLetters"
             @delete-letter="deleteLetter"
           />
@@ -50,14 +50,14 @@ export default {
       type: Object,
       required: true
     },
-    letterItems: {
+    receivedLetters: {
       type: Array,
       required: true
     },
     sentLetters: {
       type: Array,
       required: true
-    }
+    },
   },
   data() {
     return {

--- a/app/javascript/pages/mypage/index.vue
+++ b/app/javascript/pages/mypage/index.vue
@@ -29,6 +29,7 @@
       :received-letters="receivedLetters"
       :sent-letters="sentLetters"
       @delete-letter="fetchReceivedLetters"
+      @update-letter="fetchSentLetters"
     />
   </v-container>
 </template>

--- a/app/javascript/pages/mypage/index.vue
+++ b/app/javascript/pages/mypage/index.vue
@@ -26,7 +26,7 @@
     </transition>
     <LetterListTab
       :user="user"
-      :letter-items="receivedLetters"
+      :received-letters="receivedLetters"
       :sent-letters="sentLetters"
       @delete-letter="fetchReceivedLetters"
     />

--- a/app/javascript/pages/user/index.vue
+++ b/app/javascript/pages/user/index.vue
@@ -39,12 +39,9 @@
         @close-modal="handleCloseCreateLetterModal"
       />
     </transition>
-    <DoneSendLetter
-        :user="user"
-    />
     <LetterListTab
       :user="user"
-      :letter-items="receivedLetters"
+      :received-letters="receivedLetters"
       :sent-letters="sentLetters"
     />
   </v-container>


### PR DESCRIPTION
- v-forでモーダルを複数開いてしまうことによる無限ループエラーを回避するためにv-cardをコンポーネント化

- 編集モーダルコンポーネントを実装

- レター表示コンポーネント内のpropsの名前を一部変更

- 削除機能のエラーを解消（lettersテーブル、receiversテーブルをそれぞれ参照出来ていなかった）

- 編集ボタンを押すとレターが更新

- レターは登録日時で昇順にリスト表記されること
