### PR TITLE
Twitterbot専用のルーティングを設定しmetaデータを反映させる

### DIFF
--- a/app/controllers/crawlers_controller.rb
+++ b/app/controllers/crawlers_controller.rb
@@ -1,7 +1,6 @@
 class CrawlersController < ApplicationController
 
   def show
-    @share_letter_image = url("/img/mybox/jpg")
-    # public/img/mybox.jpgをツイート時のデフォルトのOGP画像として反映させること・動的に変更する条件分岐
+    @user = User.find_by!(twitter_id: params[:twitter_id])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,7 +16,6 @@ module ApplicationHelper
       twitter: {
         site: '@goenbako',
         card: 'summary_large_image',
-        image: 'https://goenbako.com/img/logo.png'
       },
     }
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
         title: "ご縁箱",
         description: "Twitterシェアに特化したファンレター公開サービスです。ご縁箱をかんたん開設したらあなたのファンにTwitterでシェアしてみましょう！",
         type: "website",
-        url: [request.original_url, 'http://127.0.0.1:3000'],
+        url: 'https://goenbako.com',
         image: 'https://goenbako.com/img/logo.png',
         locale: "ja_JP"
       },

--- a/app/javascript/pages/components/ShareLetterModal.vue
+++ b/app/javascript/pages/components/ShareLetterModal.vue
@@ -142,8 +142,8 @@ export default {
       this.$emit("close-modal");
     },
     twitterShare() {
-      const url = `${location.origin}/${this.currentUser.twitter_id}`
-      return `https://twitter.com/share?text=${this.receivedLetter.sender.name}さんからファンレターが届いたよ！%0a&url=${url}&hashtags=ご縁箱`;
+      const url = `https://goenbako.com/${this.currentUser.twitter_id}`
+      return `https://twitter.com/share?text=${this.receivedLetter.sender.name}さん からファンレターが届いたよ！%0a&url=${url}&hashtags=ご縁箱`;
     },
   },
 };

--- a/app/views/crawlers/show.html.erb
+++ b/app/views/crawlers/show.html.erb
@@ -1,3 +1,4 @@
-<% set_meta_tags(og: { title: "#{@current_user.name}",
-  image: @share_letter_image.url  },
+<% set_meta_tags(og: { title: "#{@user.name}さんのご縁箱",
+  description: "みんなもファンレターを書いてみよう！",
+  image: 'https://goenbako.com/img/mybox.jpg' },
   twitter: { card: 'summary_large_image' }) %>

--- a/app/views/crawlers/show.html.erb
+++ b/app/views/crawlers/show.html.erb
@@ -1,4 +1,4 @@
-<% set_meta_tags(og: { title: "#{@user.name}さんのご縁箱",
+<% set_meta_tags(og: { title: "#{@user.name}さんのご縁箱です",
   description: "みんなもファンレターを書いてみよう！",
   image: 'https://goenbako.com/img/mybox.jpg' },
   twitter: { card: 'summary_large_image' }) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,8 +19,7 @@ Rails.application.routes.draw do
     resources :letters
   end
 
-  get 'mypage', to: 'crawlers#show',
-  constraints: { user_agent: /Twitterbot\/1.0/ }
+  get '/:twitter_id', to: 'crawlers#show', constraints: { user_agent: /Twitterbot/ }
 
   get '*path', to: 'home#index'
 end


### PR DESCRIPTION
## 概要
- Twitterクローラーからのアクセス時のルーティングを記述
- crawlersコントローラーとビューを設定
- meta-tagsの設定




## クローラーについて
TwitterのクローラーであるTwitterBotは、JavaScriptのレンダリングを認識してくれません。

したがって、JavaScriptでメタタグなどを設定してもOGP画像に反映出来ません。

そのため、SPAでTwitterOGP画像を動的に行うには手間を加える必要があります。

MPAとSSRの切り替えがしやすいというNuxt.jsで実現する例は多数見受けられましたが、RailsでのSPAにおいてはサーバーサイドレンダリングするのは実装コストが高く、アンチパターンのようです。
他の手段を探してみました。

[Netlify]の有料（9USD）プランを使用して自動的にprerenderingを行う設定にする
Twitterのクローラーからのアクセス専用のルーティングを設定し、Rails側で処理した上でOGPメタタグ入りのHTMLを返す
railsで完結出来る後者が実装的に良さそうです。

イメージが曖昧なままでは実装の仕様がなかったのですが、理解出来ていなくて詰まったポイントを紹介します。
それは、
『どこでどのタイミングでTwitterのクローラーがアプリにアクセスしてくるのか』です。

結論は、
『Twitterシェアボタンをアプリ側で押して遷移した後、パラメータとして渡したURLがツイート画面に表示される時』です。

ここで初めて、Twitterのクローラーが「このURLはなんだ？」とアクセスした上でmetaタグ等を調べてくるイメージです。
したがって開発環境ではいくら検証しようとしてもクローラーは本番のURLにアクセスするため、OGPが適用されることはないですし
ローカルのサーバーログでは確認のしようがありません。
herokuのサーバーログには出力されると思ったのですが、本番のログにも反映はないため確認は本番環境にpushして
自分で操作しながらかカードバリデータなどを使ってみると良いかもしれません。


この画面が表示される際にクローラーがツイート画面のURLにアクセスしてmeta情報などを読み込みます。

![image](https://user-images.githubusercontent.com/78721963/146306240-b927c045-fc26-475d-af47-3d782635749b.png)

/twitter_id にアクセスされた、かつTwitterのクローラーからのアクセスの場合はcrawlers#showのアクションを実行する場合、以下のように書きます。
```
  get '/:twitter_id', to: 'crawlers#show', constraints: { user_agent: /Twitterbot/ }
```
あとはViewsファイルにmetaタグを書いておけばOGPにも反映されるように実装することが出来ます。


