### PR TITLE
ShareImageモデル（レターシェアOGP画像）

### DIFF
--- a/app/controllers/api/share_images_controller.rb
+++ b/app/controllers/api/share_images_controller.rb
@@ -1,0 +1,18 @@
+class Api::ShareImagesController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    @share_image = ShareImage.new(share_image_params)
+      if @share_image.save
+        render json: @share_image, status: :ok
+    else
+      render json: @share_image, status: :bad_request
+    end
+  end
+
+  private
+
+  def share_image_params
+    params.require(:share_image).permit(:letter_id, :topic, :image_url)
+  end
+end

--- a/app/javascript/components/CreateLetterModal.vue
+++ b/app/javascript/components/CreateLetterModal.vue
@@ -10,6 +10,7 @@
         <span class="m-font">ファンレター作成</span>
       </v-card-title>
       <v-divider />
+      <p class="xs-font mx-4">※それぞれ100文字以内で自由にご記入ください。</p>
       <!-- フォーム全体をHTML要素で統括 -->
       <div class="mx-4 pt-4">
         <!-- formタグでフォームデータを一括管理 -->
@@ -173,6 +174,12 @@ export default {
 .s-font{
   font-size: 0.8em;
   font-weight: bold;
+  line-height: 1;
+  color: #2c281e;
+}
+.xs-font{
+  font-size: 0.5em;
+  font-weight: lighter;
   line-height: 1;
   color: #2c281e;
 }

--- a/app/javascript/components/CreateLetterModal.vue
+++ b/app/javascript/components/CreateLetterModal.vue
@@ -130,13 +130,21 @@ export default {
       this.letter.sender_id = this.currentUser.id
       this.letter.receiver_id = this.user.id
       axios
-        .post("/api/letters", { letter: this.letter })
-        .then((res) => this.$emit("create-letter", res.data));
-        this.handleCloseModal();
+      .post("/api/letters", { letter: this.letter })
+      .then((res) => {
+          this.$emit("create-letter", res.data);
+          this.handleCloseModal();
+          this.$store.dispatch("flash/setFlash", {
+            type: "success",
+            message: "レターを作成しました。"
+          })
+      })
+      .catch((error) => {
         this.$store.dispatch("flash/setFlash", {
-          type: "success",
-          message: "レターを作成しました。"
-        });
+          type: 'error',
+          message: 'レターを作成できませんでした',
+        })
+      })
     },
     handleShowTextarea() {
       this.isShowTextarea = true

--- a/app/javascript/components/EditLetterModal.vue
+++ b/app/javascript/components/EditLetterModal.vue
@@ -10,7 +10,8 @@
         <span class="m-font">レターの更新</span>
       </v-card-title>
       <v-divider />
-      <div class="mx-4 pt-8">
+      <p class="xs-font mx-4">※それぞれ100文字以内で自由にご記入ください。</p>
+      <div class="mx-4 pt-4">
         <v-form @submit.prevent="handleUpdateLetter(letter)">
           <div v-for="(letterTitle, index) in letterTitles()" :key="index">
             <div class="s-font pa-0">
@@ -141,6 +142,12 @@ export default {
 .s-font{
   font-size: 0.8em;
   font-weight: bold;
+  line-height: 1;
+  color: #2c281e;
+}
+.xs-font{
+  font-size: 0.5em;
+  font-weight: lighter;
   line-height: 1;
   color: #2c281e;
 }

--- a/app/javascript/components/ProfileCard.vue
+++ b/app/javascript/components/ProfileCard.vue
@@ -2,31 +2,30 @@
   <v-row justify="center" class="mt-8">
     <v-card
       color="transparent"
-      min-width="320"
+      min-width="300"
+      max-width="320"
     >
-      <v-card-title class="mt-4">
-        <v-list-item-avatar size="60" class="avatar-position">
-          <img :src="currentUser.image">
-        </v-list-item-avatar>
-        <v-list-item-content>
-          <v-list-item-title class="s-font">
-          {{ currentUser.name }}
-          </v-list-item-title>
-          <v-list-item-subtitle>
-            @{{ currentUser.twitter_id }}
-            <v-btn
-              icon
-              color="blue"
-              :href="twitterUrl"
-            >
-              <v-icon>mdi-twitter</v-icon>
-            </v-btn>
-          </v-list-item-subtitle>
-        </v-list-item-content>
-      </v-card-title>
-      <v-card-text class="s-font px-4 mb-8">
-        {{ currentUser.introduce }}
-      </v-card-text>
+      <v-list-item-avatar size="60" class="avatar-position">
+        <img :src="currentUser.image">
+      </v-list-item-avatar>
+      <v-list-item-content>
+        <v-card-title class="m-font mt-4">
+        {{ currentUser.name }}
+        </v-card-title>
+        <v-card-subtitle>
+          @{{ currentUser.twitter_id }}
+          <v-btn
+            icon
+            color="blue"
+            :href="twitterUrl"
+          >
+            <v-icon>mdi-twitter</v-icon>
+          </v-btn>
+        </v-card-subtitle>
+        <v-card-text class="s-font px-4 mb-4">
+          {{ currentUser.introduce }}
+        </v-card-text>
+      </v-list-item-content>
     </v-card>
   </v-row>
 </template>
@@ -51,13 +50,13 @@ export default {
   font-weight: bold;
   line-height: 1.5;
   color: #2c281e;
-}
+} */
 .m-font{
   font-size: 1.2em;
   font-weight: bold;
   line-height: 1.3;
   color: #2c281e;
-} */
+}
 .s-font{
   font-size: 1.0em;
   font-weight: bold;

--- a/app/javascript/components/ReceivedLetterCard.vue
+++ b/app/javascript/components/ReceivedLetterCard.vue
@@ -5,10 +5,12 @@
         flat
         color="#f1f1f1"
         rounded="xl"
+        min-width="300"
+        max-width="690"
       >
-        <v-card-title class="pt-6">
+        <v-card-title class="pt-4 pb-0">
           <router-link :to="{ name: 'User', params: { twitter_id: receivedLetter.sender.twitter_id }}">
-            <v-list-item-avatar class="pa-0" size="65">
+            <v-list-item-avatar class="pa-0" size="55">
               <img :src="receivedLetter.sender.image">
             </v-list-item-avatar>
           </router-link>
@@ -33,13 +35,14 @@
           :letter-items="receivedLetter"
         />
         <v-row
+          v-if="isCurrentMypage"
           justify="end"
           class="ma-4"
         >
           <v-btn
-            v-if="isCurrentMypage"
             color="blue"
-            class="white--text"
+            class="white--text ma-1"
+
             small
             @click="openShareLetterModal"
           >
@@ -47,11 +50,10 @@
             シェア
           </v-btn>
           <v-btn
-            v-if="isCurrentMypage"
-            tile
-            small
             color="brown darken-1"
+            class="white--text ma-1"
             dark
+            small
             @click="hundleDeleteLetter(receivedLetter)"
           >
             <v-icon> mdi-delete </v-icon>
@@ -129,7 +131,7 @@ export default {
 
 <style scoped>
 .s-font{
-  font-size: 1.0em;
+  font-size: 0.8em;
   font-weight: bold;
   line-height: 1;
   color: #2c281e;

--- a/app/javascript/components/SentLetterCard.vue
+++ b/app/javascript/components/SentLetterCard.vue
@@ -5,10 +5,12 @@
         flat
         color="#f1f1f1"
         rounded="xl"
+        min-width="300"
+        max-width="690"
       >
-        <v-card-title class="pt-6">
+        <v-card-title class="pt-4 pb-0">
           <router-link :to="{ name: 'User', params: { twitter_id: sentLetter.receiver.twitter_id }}">
-            <v-list-item-avatar class="pa-0" size="65">
+            <v-list-item-avatar class="pa-0" size="55">
               <img :src="sentLetter.receiver.image">
             </v-list-item-avatar>
           </router-link>
@@ -38,8 +40,8 @@
           class="ma-4"
         >
           <v-btn
-            color="orange"
-            class="white--text"
+            color="orange lighten-1"
+            class="white--text ma-1"
             small
             @click="openEditLetterModal"
           >
@@ -47,11 +49,12 @@
             編集
           </v-btn>
           <v-btn
-            color="indigo"
-            class="white--text"
+            color="brown darken-1 ma-1"
+            dark
             small
             @click="hundleDeleteLetter(sentLetter)"
-          >削除
+          >
+            <v-icon> mdi-delete </v-icon>
           </v-btn>
         </v-row>
       </v-card>
@@ -129,7 +132,7 @@ export default {
 
 <style scoped>
 .s-font{
-  font-size: 1.0em;
+  font-size: 0.8em;
   font-weight: bold;
   line-height: 1;
   color: #2c281e;

--- a/app/javascript/components/ShareLetterModal.vue
+++ b/app/javascript/components/ShareLetterModal.vue
@@ -16,7 +16,6 @@
         <div
           class="s-font"
         >{{ letterTitle.message }}</div>
-<!-- ボタンを押したら項目に応じたデータを指定しSVGタグ側のデータに反映させる -->
         <v-card-actions class="justify-center">
           <v-btn
             color="blue"
@@ -74,7 +73,7 @@
           <text
             x="50%"
             y="50%"
-            style="line-height: 1.7; font-weight: 100; font-size: 20px"
+            style="line-height: 1.7; font-size: 20px"
             text-anchor="middle">{{ content }}
           </text>
         </foreignObject>
@@ -136,7 +135,12 @@ export default {
   },
   data() {
     return {
+    shareImage: {
+      user_id: "",
+      letter_id: "",
+      topic: "",
       image_url: '',
+    },
       title: '',
       content: ''
     }
@@ -148,6 +152,12 @@ export default {
     handleCloseModal() {
       this.$emit("close-modal");
     },
+    postImage(letterTitle) {
+      this.shareImage.user_id = this.currentUser.id
+      this.shareImage.letter_id = this.receivedLetter.letter.id
+      this.shareImage.topic = letterTitle.topic
+      axios.post("/api/share_images", { share_image: this.shareImage })
+    },
     twitterShare() {
       const url = `https://goenbako.com/${this.currentUser.twitter_id}`
       return `https://twitter.com/share?text=${this.receivedLetter.sender.name}さん からファンレターが届いたよ！%0a&url=${url}&hashtags=ご縁箱`;
@@ -158,6 +168,7 @@ export default {
         console.log(data);
         document.getElementById('converted-image').src = data;
         this.shareImage.image_url = data;
+        this.postImage(letterTitle);
       }, function (error) {
         console.log(error);
         alert('failed to image');

--- a/app/javascript/components/UserProfileCard.vue
+++ b/app/javascript/components/UserProfileCard.vue
@@ -2,31 +2,30 @@
   <v-row justify="center" class="mt-8">
     <v-card
       color="transparent"
-      min-width="320"
+      min-width="300"
+      max-width="320"
     >
-      <v-card-title class="mt-4">
-        <v-list-item-avatar size="60" class="avatar-position">
-          <img :src="user.image">
-        </v-list-item-avatar>
-        <v-list-item-content>
-          <v-list-item-title class="s-font">
+      <v-list-item-avatar size="60" class="avatar-position">
+        <img :src="user.image">
+      </v-list-item-avatar>
+      <v-list-item-content>
+        <v-card-title class="m-font mt-4">
           {{ user.name }}
-          </v-list-item-title>
-          <v-list-item-subtitle>
-            @{{ user.twitter_id }}
-            <v-btn
-              icon
-              color="blue"
-              :href="twitterUrl"
-            >
-              <v-icon>mdi-twitter</v-icon>
-            </v-btn>
-          </v-list-item-subtitle>
-        </v-list-item-content>
-      </v-card-title>
-      <v-card-text class="s-font px-4 mb-8">
-        {{ user.introduce }}
-      </v-card-text>
+        </v-card-title>
+        <v-card-subtitle>
+          @{{ user.twitter_id }}
+          <v-btn
+            icon
+            color="blue"
+            :href="twitterUrl"
+          >
+            <v-icon>mdi-twitter</v-icon>
+          </v-btn>
+        </v-card-subtitle>
+        <v-card-text class="s-font px-4 mb-8">
+          {{ user.introduce }}
+        </v-card-text>
+      </v-list-item-content>
     </v-card>
   </v-row>
 </template>
@@ -50,7 +49,12 @@ export default {
 }
 </script>
 <style scoped>
-
+.m-font{
+  font-size: 1.2em;
+  font-weight: bold;
+  line-height: 1.3;
+  color: #2c281e;
+}
 .s-font{
   font-size: 1.1em;
   font-weight: bold;

--- a/app/javascript/components/shared/TheFlashMessage.vue
+++ b/app/javascript/components/shared/TheFlashMessage.vue
@@ -31,10 +31,10 @@ export default {
 <style scoped>
 .flash {
   position: fixed;
-  top: 100px;
+  top: 80px;
   left: 20px;
   max-width: 500px;
-  z-index: 100;
+  z-index: 10000;
 }
 .v-alert--outlined {
   background: rgb(255, 255, 255) !important;

--- a/app/javascript/pages/User.vue
+++ b/app/javascript/pages/User.vue
@@ -10,7 +10,7 @@
     </v-row>
     <v-row class="justify-center mb-8 pa-4">
       <v-btn
-        v-if="this.currentUser"
+        v-if="this.isOtherCurrentUser"
         color="deep-purple lighten-5"
         rounded
         large
@@ -66,6 +66,7 @@ export default {
     };
   },
   mounted() {
+    console.log(this.$route.path);
     this.fetchUser()
     this.fetchReceivedLetters()
     this.fetchSentLetters()
@@ -74,6 +75,9 @@ export default {
     ...mapGetters("users", ["currentUser"]),
     currentPath() {
       return this.$route.path
+    },
+    isOtherCurrentUser() {
+      return this.currentUser && this.$route.path !== `/${this.currentUser.twitter_id}`
     }
   },
   methods: {

--- a/app/javascript/pages/User.vue
+++ b/app/javascript/pages/User.vue
@@ -66,7 +66,6 @@ export default {
     };
   },
   mounted() {
-    console.log(this.$route.path);
     this.fetchUser()
     this.fetchReceivedLetters()
     this.fetchSentLetters()

--- a/app/javascript/pages/User.vue
+++ b/app/javascript/pages/User.vue
@@ -77,7 +77,7 @@ export default {
       return this.$route.path
     },
     isOtherCurrentUser() {
-      return this.currentUser && this.$route.path !== `/${this.currentUser.twitter_id}`
+      return this.currentUser && this.$route.path !== `/${this.currentUser.twitter_id}` && this.$route.path !== `/${this.currentUser.twitter_id}/`
     }
   },
   methods: {

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -1,14 +1,14 @@
 import Vue from "vue";
 import Router from "vue-router";
+import store from "../store";
 import Top from "../pages/Top";
 import User from "../pages/User";
 import Mypage from "../pages/Mypage";
+import ShowLetter from "../pages/ShowLetter";
 
 Vue.use(Router)
 
-const router = new Router({
-  mode: "history",
-  routes: [
+  const routes = [
     {
       path: "/",
       component: Top,
@@ -18,16 +18,26 @@ const router = new Router({
       path: "/mypage",
       component: Mypage,
       name: "Mypage",
+      meta: { requiredLogin: true }
     },
     {
       path: "/:twitter_id",
       component: User,
       name: "User",
     },
-  ],
+    {
+      path: "/:twitter_id/letters/:letter_id",
+      component: ShowLetter,
+      name: "ShowLetter",
+    },
+  ];
+
+const router = new Router({
+  mode: "history",
+  routes,
   scrollBehavior(to, from, savedPosition) {
     return { x: 0, y: 0 }
-  }
-})
+  },
+});
 
 export default router

--- a/app/models/letter.rb
+++ b/app/models/letter.rb
@@ -1,7 +1,7 @@
 class Letter < ApplicationRecord
   belongs_to :sender, class_name: "User"
   belongs_to :receiver, class_name: "User"
-# Usersテーブルを参照するがモデルを区別する
+  has_many :share_images
 
   validates :sender_id, presence: true
   validates :receiver_id, presence: true

--- a/app/models/share_image.rb
+++ b/app/models/share_image.rb
@@ -1,0 +1,3 @@
+class ShareImage < ApplicationRecord
+  belongs_to :letter
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
       end
     end
     resources :letters
+    resources :share_images, only: %i[create]
   end
 
   get '/:twitter_id', to: 'crawlers#show', constraints: { user_agent: /Twitterbot/ }

--- a/db/migrate/20211227201446_create_share_images.rb
+++ b/db/migrate/20211227201446_create_share_images.rb
@@ -1,0 +1,11 @@
+class CreateShareImages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :share_images do |t|
+      t.references :letter, null: false
+      t.string :topic, null: false
+      t.text :image_url, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_31_071638) do
+ActiveRecord::Schema.define(version: 2021_12_27_201446) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,15 @@ ActiveRecord::Schema.define(version: 2021_10_31_071638) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["sender_id"], name: "index_letters_on_sender_id"
+  end
+
+  create_table "share_images", force: :cascade do |t|
+    t.bigint "letter_id", null: false
+    t.string "topic", null: false
+    t.text "image_url", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["letter_id"], name: "index_share_images_on_letter_id"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
## 概要
- シェアするボタンをクリックした際にbase64エンコードしたPNG画像URLを保存する処理を実装。
（保存した画像データをOGP画像に指定する）
- ShareImageモデルの設定を追記
- share_images_controller[画像保存処理]
- 画像保存処理実装[Vue側]

#### レイアウト微調節
- エラーハンドリング・メッセージ
- プロフィールカード改行対応（名前が改行されず...となる）
- layout ボタン配色
- 登録・編集モーダルに補足書き
- レターを書いてみるボタンの表示有無

![image](https://user-images.githubusercontent.com/78721963/147660327-35c7655e-eac8-4717-9d3f-f42be928dc3f.png)
