### PR TITLE
ランダム訪問機能

### DIFF
--- a/app/controllers/api/visits_controller.rb
+++ b/app/controllers/api/visits_controller.rb
@@ -1,0 +1,8 @@
+class Api::VisitsController < ApplicationController
+
+  def random
+    fetch_user = User.where( 'id >= ?', rand(User.first.id..User.last.id) ).first.twitter_id
+    render json: fetch_user
+  end
+
+end

--- a/app/javascript/components/shared/TheBottomNavigation.vue
+++ b/app/javascript/components/shared/TheBottomNavigation.vue
@@ -9,6 +9,22 @@
     </v-btn>
 
     <v-btn
+      :to="{ name: 'User', params: { twitter_id: this.random_id }}"
+    >
+      <span>Random</span>
+
+      <v-icon>mdi-paw</v-icon>
+    </v-btn>
+
+    <v-btn
+      :to="{ name: 'Mypage' }"
+    >
+      <span>Search</span>
+
+      <v-icon>mdi-account-search-outline</v-icon>
+    </v-btn>
+
+    <v-btn
       to="/api/logout"
       data-method="delete"
       @click="logoutUser"
@@ -22,15 +38,41 @@
 
 <script>
 import Cookies from 'js-cookie';
+import axios from "axios";
 
 export default {
   name: "TheBottomNavigation",
+  data() {
+    return{
+      random_id: ''
+    }
+  },
+  mounted() {
+    this.fetchRandomUser()
+  },
+  computed: {
+    currentPath() {
+      return this.$route.path
+    },
+  },
   methods: {
     logoutUser() {
-      this.$store.commit('setCurrentUser', { user:null })
+      this.$store.commit('setCurrentUser', { user: null })
       Cookies.remove('vuex');
     },
-  }
+    async fetchRandomUser() {
+      do { await axios.get("/api/random")
+        .then((res) => {
+          this.random_id = res.data
+        })
+      } while (this.$route.path === `/${this.random_id}`);
+    }
+  },
+  watch: {
+    currentPath: function() {
+      this.fetchRandomUser()
+    }
+  },
 }
 </script>
 <style scoped>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     get 'oauth/callback', to: 'oauths#callback'
     get 'oauth/:provider', to: 'oauths#oauth', as: :auth_at_provider
     delete 'logout', to: 'user_sessions#destroy'
+    get 'random', to: 'visits#random'
     resources :users, param: :twitter_id, only: %i[index edit update show destroy] do
       collection do
         get 'me'


### PR DESCRIPTION
## 概要
ランダム訪問機能を実装。
ボトムナビゲーションのRandomをクリックorタップすると
ランダムでユーザーページに遷移する。

axios→railsでレコード１件取得しtwitter_idのみをvueへ→ルーターの遷移先にtwitter_idを指定
URLのパラメータをwatchで監視→同じIDを２回連続で引いた場合はd while文でリクエストを投げ直すことでバグを抑制し連続訪問を実現。