### PR TITLE
OGPのタイトルを修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
   def default_meta_tags
     {
-      title: 'ご縁箱 - Twitterユーザー同士で楽しめる! 心温まるファンレター公開サービス',
+      title: 'ご縁箱 - Twitterユーザー同士で楽しめる!ファンレター公開サービス',
       description: 'Twitterシェアに特化したファンレター公開サービスです。ご縁箱を2秒で開設したらMyご縁箱を共有してあなたのフォロワーからファンレターを受け取ってみましょう♪',
       keywords: 'ご縁箱,goenbako,ファンレター,twitter',
       charset: 'UTF-8',

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,12 @@
 module ApplicationHelper
   def default_meta_tags
     {
-      title: 'ご縁箱 - Twitterシェアに特化したファンレター公開サービス',
+      title: 'ご縁箱 - Twitterユーザー同士で楽しめる! 心温まるファンレター公開サービス',
       description: 'Twitterシェアに特化したファンレター公開サービスです。ご縁箱を2秒で開設したらMyご縁箱を共有してあなたのフォロワーからファンレターを受け取ってみましょう♪',
       keywords: 'ご縁箱,goenbako,ファンレター,twitter',
       charset: 'UTF-8',
       og: {
-        title: 'ご縁箱 - Twitterシェアに特化したファンレター公開サービス',
+        title: '°✧˖ご縁箱˖✧° Twitterユーザー同士で楽しめる!ファンレター公開サービス',
         description: 'ご縁箱を2秒で開設したらMyご縁箱を共有してあなたのフォロワーからファンレターを受け取ってみましょう♪',
         type: 'website',
         url: 'https://goenbako.com',


### PR DESCRIPTION
# 概要
## メイン
#### ・before
      title: 'ご縁箱 - Twitterシェアに特化したファンレター公開サービス',
#### ・after
      title: 'ご縁箱 - Twitterユーザー同士で楽しめる!ファンレター公開サービス',

## OGP
#### ・before
      title: 'ご縁箱 - Twitterシェアに特化したファンレター公開サービス',
#### ・after
      title: '°✧˖ご縁箱˖✧° Twitterユーザー同士で楽しめる!ファンレター公開サービス',