### PR TITLE
base64画像化したレターをS3にアップロードして保存する処理

### DIFF
--- a/app/controllers/api/share_images_controller.rb
+++ b/app/controllers/api/share_images_controller.rb
@@ -1,15 +1,10 @@
 class Api::ShareImagesController < ApplicationController
   skip_before_action :verify_authenticity_token
+  include CarrierwaveBase64Uploader
 
   def create
     @share_image = ShareImage.new(share_image_params)
-    base64_url = @share_image.image_url['data:image/png;base64,'.length..-1]
-    decoded_data = Base64.decode64(base64_url)
-    filename = Time.zone.now.to_s + '.' + 'png'
-    File.open("#{Rails.root}/tmp/#{filename}", 'wb') do |file|
-      file.write(decoded_data)
-      @share_image.image_url = file
-    end
+    @share_image.image_url = base64_conversion(params[:share_image][:image_url])
     if @share_image.save
       render json: @share_image, status: :ok
     else
@@ -19,7 +14,7 @@ class Api::ShareImagesController < ApplicationController
 
   private
 
-    def share_image_params
-      params.require(:share_image).permit(:letter_id, :topic, :image_url)
-    end
+  def share_image_params
+    params.require(:share_image).permit(:letter_id, :topic, :image_url)
+  end
 end

--- a/app/controllers/concerns/carrierwave_base64_uploader.rb
+++ b/app/controllers/concerns/carrierwave_base64_uploader.rb
@@ -1,0 +1,31 @@
+module CarrierwaveBase64Uploader
+  extend ActiveSupport::Concern
+
+  private
+
+  def base64_conversion(uri_str, filename = 'base64')
+    image_data = split_base64(uri_str)
+    encode_data = image_data[:data]
+    decode_data = Base64.decode64(encode_data)
+
+    temp_img_file = Tempfile.new
+    temp_img_file.binmode
+    temp_img_file << decode_data
+    temp_img_file.rewind
+
+    img_params = {
+      filename: "#{SecureRandom.hex}.#{image_data[:extension]}",
+      type: image_data[:type],
+      tempfile: temp_img_file
+    }
+    ActionDispatch::Http::UploadedFile.new(img_params)
+  end
+
+  def split_base64(uri_str)
+    if uri_str.match(%r{data:(.*?);(.*?),(.*)$})
+      return { type: $1, encoding: $2, data: $3, extension: $1.split('/')[1] }
+    else
+      return nil
+    end
+  end
+end

--- a/app/models/share_image.rb
+++ b/app/models/share_image.rb
@@ -1,4 +1,4 @@
 class ShareImage < ApplicationRecord
-  # mount_uploader :image_url, ShareImageUploader
+  mount_uploader :image_url, ShareImageUploader
   belongs_to :letter
 end

--- a/app/uploaders/share_image_uploader.rb
+++ b/app/uploaders/share_image_uploader.rb
@@ -10,7 +10,7 @@ class ShareImageUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}"
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:

--- a/app/uploaders/share_image_uploader.rb
+++ b/app/uploaders/share_image_uploader.rb
@@ -10,7 +10,7 @@ class ShareImageUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}"
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,7 @@ module Goenbako
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.time_zone = 'Tokyo'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -13,4 +13,8 @@ CarrierWave.configure do |config|
     region: 'ap-northeast-1',
     path_style: true
   }
+  if Rails.env.production?
+    config.root = Rails.root.join("tmp")
+    config.cache_dir = "#{Rails.root}/tmp/uploads"
+  end
 end


### PR DESCRIPTION
## 概要
※実装の流れは[コメント](https://github.com/yanokohei/goenbako/pull/149#issuecomment-1015894913)に。

- carrierwaveの設定をS3にアップロードするように設定。
- vueでbase64エンコードした画像をデコードしてアップロードファイル形式に変換するモジュールを実装
- share_image_controller（Vueから受け取ったレターシェア画像情報を受け取ってアップロードした上で保存する処理）