### PR TITLE
URLの仕様を変更（mypage → me/home）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'sorcery'
 gem 'config'
 gem 'meta-tags'
-gem 'tailwindcss-rails'
 gem 'rails-i18n'
 gem 'carrierwave'
 gem 'fog-aws'

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,6 @@ group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
   gem 'bullet'
-  gem 'dotenv-rails'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'sorcery'
 gem 'config'
 gem 'meta-tags'
-gem 'rails-i18n'
 gem 'carrierwave'
 gem 'fog-aws'
 gem 'twitter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,9 +288,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
-    rails-i18n (6.0.0)
-      i18n (>= 0.7, < 2)
-      railties (>= 6.0.0, < 7)
     rails_best_practices (1.21.0)
       activesupport
       code_analyzer (>= 0.5.2)
@@ -450,7 +447,6 @@ DEPENDENCIES
   pry-rails
   puma (~> 4.1)
   rails (~> 6.0.4, >= 6.0.4.1)
-  rails-i18n
   rails_best_practices
   rspec-rails
   rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,10 +105,6 @@ GEM
     diff-lcs (1.4.4)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.7.6)
-    dotenv-rails (2.7.6)
-      dotenv (= 2.7.6)
-      railties (>= 3.2)
     dry-configurable (0.13.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.6)
@@ -437,7 +433,6 @@ DEPENDENCIES
   capybara
   carrierwave
   config
-  dotenv-rails
   factory_bot_rails
   fog-aws
   jbuilder (~> 2.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,8 +383,6 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     ssrf_filter (1.0.7)
-    tailwindcss-rails (0.4.3)
-      rails (>= 6.0.0)
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -462,7 +460,6 @@ DEPENDENCIES
   sorcery
   spring
   spring-watcher-listen (~> 2.0.0)
-  tailwindcss-rails
   turbolinks (~> 5)
   twitter
   tzinfo-data

--- a/app/controllers/api/oauths_controller.rb
+++ b/app/controllers/api/oauths_controller.rb
@@ -10,13 +10,13 @@ class Api::OauthsController < ApplicationController
       return
     end
     if @user = login_from(provider)
-      redirect_to mypage_path, notice: "#{provider.titleize}ログインしました。"
+      redirect_to me_home_path, notice: "#{provider.titleize}ログインしました。"
     else
       begin
         @user = create_from(provider)
         reset_session
         auto_login(@user)
-        redirect_to mypage_path, notice: "#{provider.titleize}ログインしました。"
+        redirect_to me_home_path, notice: "#{provider.titleize}ログインしました。"
       rescue StandardError
         redirect_to root_path, alert: "#{provider.titleize}ログインに失敗しました。"
       end

--- a/app/javascript/components/ProfileCard.vue
+++ b/app/javascript/components/ProfileCard.vue
@@ -6,7 +6,7 @@
       max-width="320"
     >
       <v-btn
-        v-if="this.$route.path === ('/mypage')"
+        v-if="this.$route.path === ('/me/home')"
         x-small
         class="button-position s-font"
         :to="{ name: 'Setting' }"
@@ -15,7 +15,7 @@
         <span class="ml-1">設定</span>
       </v-btn>
       <v-btn
-        v-if="this.$route.path === ('/mypage/setting')"
+        v-if="this.$route.path === ('/me/home/setting')"
         x-small
         class="button-position s-font"
         dark

--- a/app/javascript/components/ReceivedLetterCard.vue
+++ b/app/javascript/components/ReceivedLetterCard.vue
@@ -106,7 +106,7 @@ export default {
   computed: {
     ...mapGetters({ currentUser: "users/currentUser" }),
     isCurrentMypage() {
-      return this.$route.path === '/mypage'
+      return this.$route.path === '/me/home'
     }
   },
   methods: {

--- a/app/javascript/components/SentLetterCard.vue
+++ b/app/javascript/components/SentLetterCard.vue
@@ -138,7 +138,7 @@ export default {
   computed: {
     ...mapGetters({ currentUser: "users/currentUser" }),
     isCurrentMypage() {
-      return this.$route.path === '/mypage'
+      return this.$route.path === '/me/home'
     }
   },
   methods: {

--- a/app/javascript/components/ShareLinkModal.vue
+++ b/app/javascript/components/ShareLinkModal.vue
@@ -138,7 +138,7 @@ export default {
     twitterShare() {
       const url = `${location.origin}/${this.currentUser.twitter_id}`
       window.open(`https://twitter.com/intent/tweet?text=${this.userNameSaveReply}さんのご縁箱ページです。
-      %0aみんなで遊びにいってみよう♪%0a°˖✧%23ご縁箱%20%23みんなのご縁箱✧˖°%0a&url=${url}`, '_blank')
+      %0aみんなでファンレターを書いてみよう♪%0a°˖✧%23ご縁箱%20%23みんなのご縁箱✧˖°%0a&url=${url}`, '_blank')
     },
   }
 };

--- a/app/javascript/pages/Mypage.vue
+++ b/app/javascript/pages/Mypage.vue
@@ -73,7 +73,6 @@ export default {
     axios.get("/api/users/me")
     .then((res) => {
       this.user = res.data
-      console.log(this.user);
       this.$store.commit('users/setCurrentUser', res.data)
       this.fetchReceivedLetters(),
       this.fetchSentLetters()

--- a/app/javascript/pages/Mypage.vue
+++ b/app/javascript/pages/Mypage.vue
@@ -70,9 +70,10 @@ export default {
     ...mapGetters({ needHelpbox: "helpbox/needHelpbox" }),
   },
   mounted() {
-    this.$axios.get("users/me")
+    axios.get("/api/users/me")
     .then((res) => {
       this.user = res.data
+      console.log(this.user);
       this.$store.commit('users/setCurrentUser', res.data)
       this.fetchReceivedLetters(),
       this.fetchSentLetters()

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -18,12 +18,12 @@ Vue.use(Router)
       name: "Top",
     },
     {
-      path: "/mypage",
+      path: "/me/home",
       component: Mypage,
       name: "Mypage",
     },
     {
-      path: "/mypage/setting",
+      path: "/me/home/setting",
       component: Setting,
       name: "Setting",
     },

--- a/app/views/user_mailer/new_letter.html.erb
+++ b/app/views/user_mailer/new_letter.html.erb
@@ -6,7 +6,7 @@
   <p><%= @sender.name %>さんより素敵なファンレターが届いています！</p>
 
   <p>▼マイページで見る</p>
-  <p>https://goenbako.com/mypage</p>
+  <p>https://goenbako.com/me/home</p>
 
   <p>ファンレターの返信やTwitterでレターをシェアしてリアクションをしてみましょう！</p>
 

--- a/app/views/user_mailer/new_letter.text.erb
+++ b/app/views/user_mailer/new_letter.text.erb
@@ -5,7 +5,7 @@
 <%= @sender.name %>さんより素敵なファンレターが届いています！
 
 ▼マイページで見る</p>
-https://goenbako.com/mypage
+https://goenbako.com/me/home
 
 ファンレターの返信やTwitterでレターをシェアしてリアクションをしてみましょう！
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress CSS using a preprocessor.
-  config.assets.css_compressor = :purger
+  # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   root to: 'home#index'
-  get 'mypage', to: 'home#index'
+  get 'me/home', to: 'home#index'
 
   namespace :api do
     post 'oauth/callback', to: 'oauths#callback'


### PR DESCRIPTION
## 概要
#### https://goenbako.com/user_name というURLパターンの穴があった

/mypageはマイページを示す。そうするとユーザー名がmypageの人がいたら？など
その場合、今後ページを増やす場合に困ってしまう。

#### 解決方法
逆にmypageのURLはme/homeという風にして、ユーザーページとダブらせたくないURLを今後増やす場合は"/で区切る"という方針にすることで今ある懸念は避けられそう

## 実装
- [mypageをme/homeにルーティング変更](https://github.com/yanokohei/goenbako/commit/aa2f2ae12904136cc21a70a730484aa54efa1ee1)
- [mypageをme/homeにVue側のルーティング、URL変更](https://github.com/yanokohei/goenbako/commit/1eb84acaeede11d1299c9b58494d2dd3379e2ac0)
- [メール通知のmypageのURLを変更](https://github.com/yanokohei/goenbako/commit/627e1cd7aae93845dcb383686374fa3fbdd096ea)

#### その他
- 不要なGemを削除