### PR TITLE
ランダム訪問の取得方法変更

### DIFF
--- a/app/controllers/api/visits_controller.rb
+++ b/app/controllers/api/visits_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class VisitsController < ApplicationController
     def random
-      fetch_user = User.where('id >= ?', rand(User.first.id..User.last.id)).first.twitter_id
+      fetch_user = User.offset(rand(User.count)).limit(1).first.twitter_id
       render json: fetch_user
     end
   end

--- a/app/javascript/components/shared/TheBottomNavigation.vue
+++ b/app/javascript/components/shared/TheBottomNavigation.vue
@@ -149,7 +149,7 @@ export default {
     hundleRandomButton() {
       this.$router.push({ name: 'User', params: { twitter_id: this.random_id }});
       this.isRandomButton = true
-      setTimeout(() => (this.isRandomButton = false), 700)
+      setTimeout(() => (this.isRandomButton = false), 300)
     },
     logoutUser() {
       this.$store.commit('setCurrentUser', { user: null })


### PR DESCRIPTION
## 概要
原因不明だがユーザーIDの空白が生まれたことによりランダム訪問の精度が落ちてしまった。

これまでの実装方法は取得が速いが今回のようにIDに空白がある場合精度が落ちてしまう。
何故かユーザーID 133~163が空白が生まれたことによりIDが164のユーザーがヒットする確率が増加してしまった。
■修正前
```ruby
fetch_user = User.where('id >= ?', rand(User.first.id..User.last.id)).first.twitter_id
```
この場合はユーザーIDの大小の数字からランダムに取得し、空きがある場合は後に存在するIDを取得する。

ユーザー数
■修正後
```ruby
fetch_user = User.offset(rand(User.count)).limit(1).first.twitter_id
```
User.find(User.ids.sample) や User.find(User.pluck(:id).sample) とすると、Userテーブルから全てのidを取得してしまうためパフォーマンスが悪い。 今回の記述はランダムなレコードを1つだけ取得できるため、findを使用するよいかはパフォーマンスが良い。
offsetはデータの範囲を指定することができる。