### PR TITLE
【リファクタ】Gemを使ってJSONをシリアライズする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'twitter'
 gem 'administrate'
 gem 'pundit'
 gem 'serviceworker-rails'
+gem 'jb'
 
 group :development, :test do
   gem 'pry-byebug', '3.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,6 +217,7 @@ GEM
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
     ipaddress (0.8.3)
+    jb (0.8.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     jquery-rails (4.4.0)
@@ -474,6 +475,7 @@ DEPENDENCIES
   config
   factory_bot_rails
   fog-aws
+  jb
   jbuilder (~> 2.7)
   listen (~> 3.2)
   meta-tags

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@
 ・自分の率直な気持ちをレターを送って伝えることで喜んでもらえた
 
 ・ご飯の約束ができた
+
+など
 </details>
 
 <br>
@@ -63,6 +65,9 @@
 
 ## 機能紹介
 ![image](https://user-images.githubusercontent.com/78721963/155685673-158df3bc-4f66-4e53-a89a-8c92f5a9579d.png)
+
+**▼ 以下のリンクから実際のTwitterでの使われ方を閲覧することが出来ます**
+°˖✧[#goenbako_letters](https://twitter.com/search?q=%23goenbako_letters&src=typed_query&f=live) 、 [#みんなのご縁箱](https://twitter.com/search?q=%23%E3%81%BF%E3%82%93%E3%81%AA%E3%81%AE%E3%81%94%E7%B8%81%E7%AE%B1&src=typed_query&f=live)✧˖°
 
 ### メインページ
 
@@ -96,7 +101,7 @@
 | ランダム訪問 | ユーザー検索 | 設定画面 |
 | :---: | :---: | :---: |
 | <img width="760" src="https://user-images.githubusercontent.com/78721963/153412733-60cf4bce-845d-4e88-862f-a17af925ecd6.gif"> | <img width="750" src="https://user-images.githubusercontent.com/78721963/155651314-5292d82a-3618-42af-a2ca-18b1903c5713.png"> | <img width="750" src="https://user-images.githubusercontent.com/78721963/155473003-da991f0a-6156-4a6c-8fd2-a129f3ebf36c.png"> |
-| ご縁箱ページをランダムに訪問出来る（誰でも閲覧可） | TwitterIDで検索。失敗時に開設リクエスト案内(任意) | メール通知設定、Twitterアカ情報再取得 |
+| ご縁箱ページをランダムに訪問出来る（誰でも閲覧可） | TwitterIDで検索。失敗時に開設リクエスト案内(任意) | メール通知設定、Twitterアカウント情報の再取得 |
 
 <br>
 
@@ -143,7 +148,7 @@ vuex-persistedstate ・・・ ログインユーザの状態をcookieに保持�
 js-cookie ・・・ cookieに保存したstateを操作する際に使用
 
 axios ・・・ リクエストを投げてサーバとデータの取得や送信のやり取りを行う
-  
+
 vee-validate ・・・ E-mailの入力フォームに使用
 
 vue-gtag ・・・ Googleアナリティクスの設定
@@ -168,7 +173,7 @@ eslint ・・・ リントチェック
 
 <img src="https://img.shields.io/badge/-Qiita-55C500.svg?logo=&style=flat-square">[【個人開発】Twitterで映える！ファンレターを交換・シェアして楽しめるサービス『ご縁箱』をリリースしました✧˖°。](https://qiita.com/o83184206/items/dcab2743fea236f0aa67)
 
-#### 2022/2/24 現在
-- #### 総PV数・・・22,000回を突破
-- #### UU数・・・・750人を突破
+#### 2022/3/22 現在
+- #### 総PV数・・・25,000回を突破
+- #### UU数・・・・900人を突破
 - #### 会員数 ・・・130人を突破

--- a/app/controllers/api/letters_controller.rb
+++ b/app/controllers/api/letters_controller.rb
@@ -41,7 +41,7 @@ module Api
       letter = if params[:sent_case]
                  current_user.letters.find(params[:id])
                else
-                 current_user.receivers.find(params[:id])
+                 current_user.received_letters.find(params[:id])
                end
       letter.destroy!
       render json: letter
@@ -50,7 +50,7 @@ module Api
     private
 
       def set_letter
-        @letter = current_user.letters.find_by(id: params[:id]) || current_user.receivers.find_by(id: params[:id])
+        @letter = current_user.letters.find_by(id: params[:id]) || current_user.received_letters.find_by(id: params[:id])
       end
 
       def letter_params

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -4,28 +4,15 @@ module Api
 
     def sent_letters
       user = User.find_by!(twitter_id: params[:twitter_id])
-      sent_letters = user.letters.order(created_at: :desc)
-      sent_letters = sent_letters.map do |letter|
-        {
-          letter: letter,
-          sender: letter.sender,
-          receiver: letter.receiver
-        }
-      end
-      render json: sent_letters
+      @sent_letters = user.letters.order(created_at: :desc)
+      render 'jb/sent_letters.json.jb'
+
     end
 
     def received_letters
       user = User.find_by!(twitter_id: params[:twitter_id])
-      received_letters = user.receivers.order(created_at: :desc)
-      received_letters = received_letters.map do |letter|
-        {
-          letter: letter,
-          sender: letter.sender,
-          receiver: letter.receiver
-        }
-      end
-      render json: received_letters
+      @received_letters = user.received_letters.order(created_at: :desc)
+      render 'jb/received_letters.json.jb'
     end
 
     def show

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -10,8 +10,6 @@ class UserDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     authentications: Field::HasMany,
     letters: Field::HasMany,
-    sent_letters: Field::HasMany,
-    receivers: Field::HasMany,
     received_letters: Field::HasMany,
     id: Field::Number,
     twitter_id: Field::String,
@@ -33,7 +31,7 @@ class UserDashboard < Administrate::BaseDashboard
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
-  SHOW_PAGE_ATTRIBUTES = [:authentications, :letters, :sent_letters, :receivers, :received_letters, :id, :twitter_id, :name, :image, :introduce,
+  SHOW_PAGE_ATTRIBUTES = [:authentications, :letters, :received_letters, :id, :twitter_id, :name, :image, :introduce,
                           :role, :created_at, :updated_at, :email].freeze
 
   # FORM_ATTRIBUTES

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
 
   has_many :authentications, dependent: :destroy
   has_many :letters, foreign_key: :sender_id, dependent: :destroy, inverse_of: 'sender'
-  has_many :receivers, class_name: 'Letter', foreign_key: :receiver_id, dependent: :destroy, inverse_of: 'receiver'
+  has_many :received_letters, class_name: 'Letter', foreign_key: :receiver_id, dependent: :destroy, inverse_of: 'receiver'
 
   accepts_nested_attributes_for :authentications
 

--- a/app/views/jb/received_letters.json.jb
+++ b/app/views/jb/received_letters.json.jb
@@ -1,0 +1,7 @@
+@received_letters.map do |letter|
+  {
+    letter: letter,
+    sender: letter.sender,
+    receiver: letter.receiver
+  }
+end

--- a/app/views/jb/sent_letters.json.jb
+++ b/app/views/jb/sent_letters.json.jb
@@ -1,0 +1,7 @@
+@sent_letters.map do |letter|
+  {
+    letter: letter,
+    sender: letter.sender,
+    receiver: letter.receiver
+  }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe User, type: :model do
       is_expected.to have_many(:letters).dependent(:destroy)
     end
 
-    it 'has_many :receivers, destroy' do
-      is_expected.to have_many(:receivers).dependent(:destroy)
+    it 'has_many :received_letters, destroy' do
+      is_expected.to have_many(:received_letters).dependent(:destroy)
     end
   end
 


### PR DESCRIPTION
## 概要
controllerでjsonを返す際にmapで長くなっているためスッキリさせる。

Gem [jb](https://github.com/amatsuda/jb) を使用。
ご縁箱は規模拡張性や複雑性はないものの通信頻度は多いため、速度を重視したい。その点で相性が良い。

・速さ(公式に他のGemとの比較とどれくらい速くなるかのデータあり)
・書きやすさ（DSLではなくRuby色が強い）
・複雑な実装をしていない
・開発者（nokogiriを開発した人。メンテもされている）

## 実装
- [gem 'jb' install](https://github.com/yanokohei/goenbako/commit/9d5d97af5f0c00bd6bc703ea5a42132c1115a1dc)
- [controllerの修正](https://github.com/yanokohei/goenbako/commit/ca863562da9f34b066c8aa0f26c9b8cf9b7ad864)  
  - render 'ファイル名'とする。拡張子をjbにするだけで良い。
- [レターのJSONファイルを切り分け](https://github.com/yanokohei/goenbako/commit/90a9c534221d55f963c23453f026961e1fb15c7f)
  - renderするjsonを定義。DSLで書くjbuilderと違ってrubyの構文で書ける点が魅力。